### PR TITLE
Fix ring buffer dumping, PsiAccount destruction

### DIFF
--- a/src/psiaccount.cpp
+++ b/src/psiaccount.cpp
@@ -1229,11 +1229,12 @@ PsiAccount::PsiAccount(const UserAccount &acc, PsiContactList *parent, CapsRegis
 
 PsiAccount::~PsiAccount()
 {
+	logout(true, loggedOutStatus());
+
 	emit accountDestroyed();
 	// nuke all related dialogs
 	deleteAllDialogs();
 
-	logout(true, loggedOutStatus());
 	QString str = name();
 
 	while (!d->messageQueue.isEmpty())


### PR DESCRIPTION
- Fixes a bug occurring when the XML ring buffer is getting dumped while completely filled, causing the oldest entry of the buffer to show up last.
- Fixes PsiAccount destructor by logging out before emitting accountDestroyed - prevents plugins from crashing when accessing account information on logout.
