### PR TITLE
Fix for "Get rid of "Unable to retrieve your account information." dialogue"

### DIFF
--- a/src/psiaccount.cpp
+++ b/src/psiaccount.cpp
@@ -2866,17 +2866,22 @@ void PsiAccount::sentInitialPresence()
 {
 	QTimer::singleShot(15000, this, SLOT(enableNotifyOnline()));
 
-	// Get the vcard
-	const VCard *vcard = VCardFactory::instance()->vcard(d->jid);
-	if (PsiOptions::instance()->getOption("options.vcard.query-own-vcard-on-login").toBool() || !vcard || vcard->isEmpty() || (vcard->nickName().isEmpty() && vcard->fullName().isEmpty()))
-		VCardFactory::instance()->getVCard(d->jid, d->client->rootTask(), this, SLOT(slotCheckVCard()));
-	else {
-		d->nickFromVCard = true;
-		// if we get here, one of these fields is non-empty
-		if (!vcard->nickName().isEmpty()) {
-			setNick(vcard->nickName());
-		} else {
-			setNick(vcard->fullName());
+	// Check if the vCard should be updated on login
+	if (PsiOptions::instance()->getOption("options.vcard.query-own-vcard-on-login").toBool()) {
+
+		// Update vCard
+		const VCard *vcard = VCardFactory::instance()->vcard(d->jid);
+		if (!vcard || vcard->isEmpty() || (vcard->nickName().isEmpty() && vcard->fullName().isEmpty())) {
+			VCardFactory::instance()->getVCard(d->jid, d->client->rootTask(), this, SLOT(slotCheckVCard()));
+		}
+		else {
+			d->nickFromVCard = true;
+			// if we get here, one of these fields is non-empty
+			if (!vcard->nickName().isEmpty()) {
+				setNick(vcard->nickName());
+			} else {
+				setNick(vcard->fullName());
+			}
 		}
 	}
 }


### PR DESCRIPTION
A fix for https://github.com/psi-im/psi/issues/4

Problem was the "Unable to fetch vCard" dialogue popping up even when options.vcard.query-own-vcard-on-login was set to false. The cause for this was a logical error in the if-statement determining whether to fetch a vCard or not. If no vCard was available a fetch was performed no matter of the value of options.vcard.query-own-vcard-on-login.

This patch wraps the whole vCard update code in a if-statement which checks the options.vcard.query-own-vcard-on-login option.

Verified that this patch fixes the "Unable to retrieve your account information." issue when options.vcard.query-own-vcard-on-login is set to false.

(It would probably be nice to have a checkbox for this option within the ordinary settings but that's a different issue).
