### PR TITLE
Subdirectory `translations' is now used for translation files.

### DIFF
--- a/src/translationmanager.cpp
+++ b/src/translationmanager.cpp
@@ -172,7 +172,10 @@ VarList TranslationManager::availableTranslations()
 QStringList TranslationManager::translationDirs() const
 {
 	QStringList dirs;
-	QString subdir = "";
+	dirs += ".";
+	dirs += ApplicationInfo::homeDir(ApplicationInfo::DataLocation);
+	dirs += ApplicationInfo::resourcesDir();
+	QString subdir = "/translations";
 	dirs += "." + subdir;
 	dirs += ApplicationInfo::homeDir(ApplicationInfo::DataLocation) + subdir;
 	dirs += ApplicationInfo::resourcesDir() + subdir;


### PR DESCRIPTION
(Old paths are also checked for back compatibility)
