### PR TITLE
'Show popups' checkbox in main menu (updated)

### DIFF
--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -511,6 +511,7 @@ void MainWin::registerAction( IconAction* action )
 		{ "menu_change_profile", activated, this, SIGNAL( changeProfile() ) },
 		{ "menu_quit",           activated, this, SLOT( try2tryCloseProgram() ) },
 		{ "menu_play_sounds",    toggled,   this, SLOT( actPlaySoundsActivated(bool) ) },
+    { "menu_show_popups",    toggled,   this, SLOT( actShowPopupsActivated(bool) ) },
 #ifdef USE_PEP
 		{ "publish_tune",        toggled,   this, SLOT( actPublishTuneActivated(bool) ) },
 #endif
@@ -552,6 +553,9 @@ void MainWin::registerAction( IconAction* action )
 			// special cases
 			if ( aName == "menu_play_sounds" ) {
 				action->setChecked(PsiOptions::instance()->getOption("options.ui.notifications.sounds.enable").toBool());
+			}
+      if ( aName == "menu_show_popups" ) {
+				action->setChecked(PsiOptions::instance()->getOption("options.ui.notifications.passive-popups.enabled").toBool());
 			}
 			//else if ( aName == "foobar" )
 			//	;
@@ -797,7 +801,7 @@ void MainWin::buildMainMenu()
 	if (PsiOptions::instance()->getOption("options.ui.menu.main.change-profile").toBool()) {
 		actions << "menu_change_profile";
 	}
-	actions << "menu_play_sounds";
+  actions << "menu_show_popups" << "menu_play_sounds";
 
 	d->updateMenu(actions, d->mainMenu);
 }
@@ -830,7 +834,7 @@ void MainWin::buildGeneralMenu(QMenu* menu)
 	if (PsiOptions::instance()->getOption("options.ui.menu.main.change-profile").toBool()) {
 		actions << "menu_change_profile";
 	}
-	actions << "menu_play_sounds";
+	actions << "menu_show_popups" << "menu_play_sounds";
 
 	d->updateMenu(actions, menu);
 }
@@ -964,6 +968,11 @@ void MainWin::actDiagQCAKeyStoreActivated()
 void MainWin::actPlaySoundsActivated (bool state)
 {
 	PsiOptions::instance()->setOption("options.ui.notifications.sounds.enable", state);
+}
+
+void MainWin::actShowPopupsActivated (bool state)
+{
+	PsiOptions::instance()->setOption("options.ui.notifications.passive-popups.enabled", state);
 }
 
 void MainWin::actPublishTuneActivated (bool state)

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -128,6 +128,7 @@ private slots:
 	void actAboutQtActivated ();
 	void actAboutPsiMediaActivated ();
 	void actPlaySoundsActivated (bool);
+  void actShowPopupsActivated (bool);
 	void actPublishTuneActivated (bool);
 	void actTipActivated();
 	void actDiagQCAPluginActivated();

--- a/src/psiactionlist.cpp
+++ b/src/psiactionlist.cpp
@@ -221,6 +221,9 @@ void PsiActionList::Private::createMainWin()
 
 		IconAction *actPlaySounds = new IconAction (tr("Play Sounds"), "psi/playSounds", tr("Play &Sounds"), 0, this, 0, true);
 		actPlaySounds->setWhatsThis (tr("Toggles whether sound should be played or not"));
+    
+    IconAction *actShowPopups = new IconAction (tr("Show popups"), "psi/events", tr("Show &Popups"), 0, this, 0, true);
+		actShowPopups->setWhatsThis (tr("Toggles whether popups should be displayed or not"));
 		
 		IconAction *actQuit = new IconAction (tr("Quit"), "psi/quit", tr("&Quit"), 0, this);
 		actQuit->setMenuRole(QAction::QuitRole);
@@ -245,6 +248,7 @@ void PsiActionList::Private::createMainWin()
 			{ "menu_xml_console",     lw_act           },
 			{ "menu_change_profile",  actChangeProfile },
 			{ "menu_play_sounds",     actPlaySounds    },
+      { "menu_show_popups",     actShowPopups    },
 			{ "menu_quit",            actQuit          },
 			{ "", 0 }
 		};


### PR DESCRIPTION
Hi! I have written a patch what adds new option in general menu for fast access to enable/disable popups option.
It can be very useful like fast access to enable/disable sound option.
