### PR TITLE
Add detection of RFRemix into unixHeuristicDetect()

### DIFF
--- a/src/systeminfo.cpp
+++ b/src/systeminfo.cpp
@@ -88,6 +88,7 @@ static QString unixHeuristicDetect() {
 
 		LinuxASP, // Russian Linux distros
 		LinuxALT,
+		LinuxRFRemix,
 
 		LinuxPLD, // Polish Linux distros
 		LinuxAurox,
@@ -116,6 +117,7 @@ static QString unixHeuristicDetect() {
 		{ LinuxAurox,		OsUseName,	"/etc/aurox-release",		"Aurox Linux"		},
 		{ LinuxArch,		OsUseFile,	"/etc/arch-release",		"Arch Linux"		},
 		{ LinuxLFS,		OsAppendFile,	"/etc/lfs-release",		"LFS Linux"		},
+		{ LinuxRFRemix,		OsUseFile,	"/etc/rfremix-release",		"RFRemix Linux"		},
 
 		// untested
 		{ LinuxSuSE,		OsUseFile,	"/etc/SuSE-release",		"SuSE Linux"		},


### PR DESCRIPTION
Affects only *nix systems where lsb_release is not installed.
(patch from Psi+, thanks to taurus)
