### PR TITLE
save X11 window class when changing window name

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -386,15 +386,18 @@ void closeDialogs(QWidget *w)
 
 void x11wmClass(Display *dsp, WId wid, QString resName)
 {
-	const char *app_name = ApplicationInfo::sname().latin1();
-
 	//Display *dsp = x11Display();				 // get the display
 	//WId win = winId();						   // get the window
 	XClassHint classhint;						  // class hints
+	// Get old class hint. It is important to save old class name
+	XGetClassHint(dsp, wid, &classhint);
+	XFree(classhint.res_name);
+
 	const QByteArray latinResName = resName.toLatin1();
 	classhint.res_name = (char *)latinResName.data(); // res_name
-	classhint.res_class = const_cast<char*>(app_name);				// res_class
 	XSetClassHint(dsp, wid, &classhint);		   // set the class hints
+
+	XFree(classhint.res_class);
 }
 
 //>>>-- Nathaniel Gray -- Caltech Computer Science ------>


### PR DESCRIPTION
Qt has internal logic to set X11 window class name.
It based (but not identical) on binary name.
It is important to not change class name.
It uses for window grouping and in some rules of some WMs.
