### PR TITLE
fix IconAction::setParent

### DIFF
--- a/src/widgets/iconaction.cpp
+++ b/src/widgets/iconaction.cpp
@@ -370,6 +370,19 @@ IconAction &IconAction::operator=( const IconAction &from )
 	return *this;
 }
 
+void IconAction::setParent(QObject *newParent)
+{
+	QWidget *oldParent = qobject_cast<QWidget*>(parent());
+	if (oldParent) {
+		oldParent->removeAction(this);
+	}
+
+	QAction::setParent(newParent);
+	if (newParent && newParent->isWidgetType()) {
+		((QWidget *)newParent)->addAction(this);
+	}
+}
+
 //----------------------------------------------------------------------------
 // IconActionGroup
 //----------------------------------------------------------------------------

--- a/src/widgets/iconaction.h
+++ b/src/widgets/iconaction.h
@@ -58,6 +58,8 @@ public:
 	virtual IconAction *copy() const;
 	virtual IconAction &operator=( const IconAction & );
 
+	void setParent(QObject *newParent);
+
 public slots:
 	void setEnabled(bool);
 	void setChecked(bool);


### PR DESCRIPTION
In IconAction constructor action will be added to parent QWidget
(if set). setParent function must implement such behavour too.
