### PR TITLE
Fixing casting from pointer to int

### DIFF
--- a/src/psitrayicon.cpp
+++ b/src/psitrayicon.cpp
@@ -188,7 +188,7 @@ void PsiTrayIcon::animate()
 		return;
 
 	QString cachedName = "PsiTray/" + PsiOptions::instance()->getOption("options.iconsets.status").toString()
-			+ "/" + icon_->name() + "/" + QString::number(int(icon_)) + "/"
+			+ "/" + icon_->name() + "/" + QString::number(intptr_t(icon_)) + "/"
 			+ QString::number( icon_->frameNumber() );
 
 	QPixmap p;


### PR DESCRIPTION
src/psitrayicon.cpp converted icon_ (a pointer) to int, which caused
error when compiled for 64 bit. Therefor the casting was changed to
intptr_t inorder to solve the compilation error.
