### PR TITLE
fixed to obtain the client's name, if the caps node contains https

### DIFF
--- a/src/capabilities/capsmanager.cpp
+++ b/src/capabilities/capsmanager.cpp
@@ -263,6 +263,8 @@ QString CapsManager::clientName(const Jid& jid) const
 			name = cs.node();
 			if (name.startsWith("http://"))
 				name = name.right(name.length() - 7);
+			else if (name.startsWith("https://"))
+				name = name.right(name.length() - 8);
 
 			if (name.startsWith("www."))
 				name = name.right(name.length() - 4);


### PR DESCRIPTION
node1 = "http://www.host.net/blablabla"
node2 = "https://www.host.net/blablabla"

behavior before:
name1="host.net"
name2="https:"

behavior after:
name1="host.net"
name2="host.net"
