### PR TITLE
Use a semitransparent black shadow for embiggened tray icons

### DIFF
--- a/src/psitrayicon.cpp
+++ b/src/psitrayicon.cpp
@@ -139,10 +139,10 @@ QPixmap PsiTrayIcon::makeIcon()
 	// draw a dropshadow
 	for(n2 = 0; n2 < in.height(); ++n2) {
 		for(n = 0; n < in.width(); ++n) {
-			if(int a = qAlpha(in.pixel(n,n2))) {
+			if(int a = qAlpha(in.pixel(n,n2)) / 2) {
 				int x = n + xo + 2;
 				int y = n2 + yo + 2;
-				real.setPixel(x, y, qRgba(0x80,0x80,0x80,a));
+				real.setPixel(x, y, qRgba(0,0,0,a));
 			}
 		}
 	}


### PR DESCRIPTION
On X11, Psi previously added an opaque gray "shadow" to tray icons which
looks out of place on dark or colored panels. A semitransparent black
shadow should look cromulent on any panel color.

![Comparison of Tray icon shadows](https://cloud.githubusercontent.com/assets/917394/2875733/2428e4cc-d425-11e3-9018-fe4e9650e55c.png)
On the left is the previous shadow, on the right the new shadow.
