### PR TITLE
Don't unassign non-matching OpenPGP keys

### DIFF
--- a/src/psiaccount.cpp
+++ b/src/psiaccount.cpp
@@ -5597,10 +5597,6 @@ void PsiAccount::pgp_verifyFinished()
 			ur.setPublicKeyID(signer.key().pgpPublicKey().keyId());
 			ur.setPGPVerifyStatus(signer.identityResult());
 			ur.setSigTimestamp(signer.timestamp());
-
-			// if the key doesn't match the assigned key, unassign it
-			if(signer.key().pgpPublicKey().keyId() != u->publicKeyID())
-				u->setPublicKeyID("");
 		}
 		else {
 			ur.setPGPVerifyStatus(-1);


### PR DESCRIPTION
If a contact creates a new signing subkey which is not yet known to us,
Psi shouldn't unassign the master key.
