### PR TITLE
Dropped XMPP::Base64

### DIFF
--- a/src/tools/optionstree/optionstreereader.cpp
+++ b/src/tools/optionstree/optionstreereader.cpp
@@ -6,7 +6,6 @@
 
 #include "optionstree.h"
 #include "varianttree.h"
-#include "xmpp/base64/base64.h"
 
 OptionsTreeReader::OptionsTreeReader(OptionsTree* options)
 	: options_(options)
@@ -80,7 +79,7 @@ QVariant OptionsTreeReader::readVariant(const QString& type)
 	}
 	else if (type == "QByteArray") {
 		result = QByteArray();
-		result = XMPP::Base64::decode(readElementText());
+		result = QByteArray::fromBase64(readElementText().toLatin1());
 	}
 	else {
 		QVariant::Type varianttype;

--- a/src/tools/optionstree/optionstreewriter.cpp
+++ b/src/tools/optionstree/optionstreewriter.cpp
@@ -7,7 +7,6 @@
 
 #include "optionstree.h"
 #include "varianttree.h"
-#include "xmpp/base64/base64.h"
 
 OptionsTreeWriter::OptionsTreeWriter(const OptionsTree* options)
 	: options_(options)
@@ -105,7 +104,7 @@ void OptionsTreeWriter::writeVariant(const QVariant& variant)
 		writeTextElement("height", QString::number(variant.toRect().height()));
 	}
 	else if (variant.type() == QVariant::ByteArray) {
-		writeCharacters(XMPP::Base64::encode(variant.toByteArray()));
+		writeCharacters(variant.toByteArray().toBase64());
 	}
 	else if (variant.type() == QVariant::KeySequence) {
 		QKeySequence k = variant.value<QKeySequence>();

--- a/src/tools/optionstree/unittest/unittest.pri
+++ b/src/tools/optionstree/unittest/unittest.pri
@@ -2,7 +2,6 @@ OPTIONSTREE_CPP = ..
 CONFIG += optionstree
 include(../optionstree.pri)
 include(../../atomicxmlfile/atomicxmlfile.pri)
-include(../../../../iris/src/xmpp/base64/base64.pri)
 
 SOURCES += \
 	$$PWD/OptionsTreeMainTest.cpp

--- a/src/tools/optionstree/varianttree.cpp
+++ b/src/tools/optionstree/varianttree.cpp
@@ -28,9 +28,6 @@
 #include <QKeySequence>
 #include <QStringList>
 #include <QColor>
-#include "xmpp/base64/base64.h"
-
-using namespace XMPP;
 
 // FIXME: Helpers from xmpp_xmlcommon.h would be very appropriate for
 // void VariantTree::variantToElement(const QVariant& var, QDomElement& e)
@@ -449,7 +446,7 @@ QVariant VariantTree::elementToVariant(const QDomElement& e)
 		value = QByteArray();
 		for (QDomNode node = e.firstChild(); !node.isNull(); node = node.nextSibling()) {
 			if (node.isText()) {
-				value = Base64::decode(node.toText().data());
+				value = QByteArray::fromBase64(node.toText().data().toLatin1());
 				break;
 			}
 		}
@@ -537,7 +534,7 @@ void VariantTree::variantToElement(const QVariant& var, QDomElement& e)
 		e.appendChild(height_element);
 	}
 	else if (type == "QByteArray") {
-		QDomText text = e.ownerDocument().createTextNode(Base64::encode(var.toByteArray()));
+		QDomText text = e.ownerDocument().createTextNode(var.toByteArray().toBase64());
 		e.appendChild(text);
 	}
 	else if (type == "QKeySequence") {


### PR DESCRIPTION
Use standard QByteArray::from/toBase64 instead of.
