### PR TITLE
Don't use the throbber icon if stream management is inactive

### DIFF
--- a/src/psichatdlg.cpp
+++ b/src/psichatdlg.cpp
@@ -591,10 +591,10 @@ void PsiChatDlg::doSend() {
 	}
 	if (account()->client()->isStreamManagementActive()) {
 		unacked_messages++;
+		//qDebug("Show throbber instead of status icon.");
+		ui_.lb_status->setPsiIcon(throbber_icon);
+		setContactToolTip(last_contact_tooltip);
 	}
-	//qDebug("Show throbber instead of status icon.");
-	ui_.lb_status->setPsiIcon(throbber_icon);
-	setContactToolTip(last_contact_tooltip);
 }
 
 void PsiChatDlg::ackLastMessages(int msgs) {


### PR DESCRIPTION
On accounts without stream management, the throbber icon was displayed after sending a message and stayed until the contact changed his status.
