### PR TITLE
Use postfixed gstprovider

### DIFF
--- a/src/avcall/avcall.cpp
+++ b/src/avcall/avcall.cpp
@@ -111,13 +111,13 @@ static void ensureLoaded()
 		if(pluginFile.isEmpty())
 		{
 #if defined(Q_OS_WIN)
-			pluginFile = findPlugin(".", "gstprovider");
+			pluginFile = findPlugin(".", "gstprovider"DEBUG_POSTFIX);
 			resourcePath = QCoreApplication::applicationDirPath() + "/gstreamer-0.10";
 #elif defined(Q_OS_MAC)
-			pluginFile = findPlugin("../Plugins", "gstprovider");
+			pluginFile = findPlugin("../Plugins", "gstprovider"DEBUG_POSTFIX);
 			resourcePath = QCoreApplication::applicationDirPath() + "/../Frameworks/gstreamer-0.10";
 #else
-			pluginFile = findPlugin(ApplicationInfo::libDir() + "/plugins", "gstprovider");
+			pluginFile = findPlugin(ApplicationInfo::libDir() + "/plugins", "gstprovider"DEBUG_POSTFIX);
 #endif
 		}
 

--- a/src/src.pri
+++ b/src/src.pri
@@ -11,6 +11,14 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 unix:!mac:DEFINES += HAVE_X11
 
+CONFIG(debug, debug|release) {
+  mac: DEFINES += DEBUG_POSTFIX=\\\"_debug\\\"
+  else:win: DEFINES += DEBUG_POSTFIX=\\\"d\\\"
+  else: DEFINES += DEBUG_POSTFIX=\\\"\\\"
+}else {
+  DEFINES += DEBUG_POSTFIX=\\\"\\\"
+}
+
 # modules
 include($$PWD/protocol/protocol.pri)
 include($$PWD/irisprotocol/irisprotocol.pri)


### PR DESCRIPTION
On Windows debug dlls often have 'd' postfix.
On Mac OS X debug dylibs have _debug postfix.
Need to be sure that will be loaded correct library version.