### PR TITLE
Fix carbons for incoming PMs to other resources

### DIFF
--- a/src/psiaccount.cpp
+++ b/src/psiaccount.cpp
@@ -5149,9 +5149,9 @@ void PsiAccount::handleEvent(const PsiEvent::Ptr &e, ActivationType activationTy
 				e->setOriginLocal(true);
 				doPopup = false;
 			}
-			// throw away carbons sent to another full JID, this happens with MUC private messages carbons
-			// so we have to explicitly skip them or we'll have a lot of duplicates
-			if (m.carbonDirection() == Message::Received && d->jid != m.to()) {
+			// throw away carbons sent for MUC private messages
+			// server sends them to all resources so we have to explicitly skip them or we'll have a lot of duplicates
+			if (m.carbonDirection() == Message::Received && m.hasMUCUser()) {
 				return;
 			}
 			ChatDlg *c = findChatDialogEx(chatJid, m.carbonDirection() == Message::Sent);


### PR DESCRIPTION
Previous hack dropped all carbons for incoming PMs if they were sent to other resources.
This check was added to prevent MUC PM duplicates, but broke carbons for usual PMs sent to other resources.

This commit adds MUCUser variable which is set to true if incoming message contains
`<x xmlns="http://jabber.org/protocol/muc#user"/>`

iris patch: https://github.com/psi-im/iris/pull/46