### PR TITLE
Do not show OOB data if body contains the same data

### DIFF
--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -933,7 +933,10 @@ void ChatDlg::appendMessage(const Message &m, bool local)
 		foreach (const Url &u, urls) {
 			urlsMap.insert(u.url(), u.desc());
 		}
-		chatView()->dispatchMessage(MessageView::urlsMessage(urlsMap));
+		// Some XMPP clients send links to HTTP uploaded files both in body and in jabber:x:oob.
+		// It's convenient to show only body if OOB data brings no additional information.
+		if (!(urlsMap.size() == 1 && urlsMap.contains(body) && urlsMap.value(body).isEmpty()))
+			chatView()->dispatchMessage(MessageView::urlsMessage(urlsMap));
 	}
 
 	// if we're not active, notify the user by changing the title


### PR DESCRIPTION
Some XMPP clients (e.g. Conversations) send links to HTTP uploaded files
both in body and in `jabber:x:oob`.
Psi shows both (same) links in chat window. While technically this behavior is correct,
it's convenient to show only one link if OOB data is equal to message body (only one URL without description).