### PR TITLE
WebView: Do not copy empty selection to clipboard

### DIFF
--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -183,7 +183,7 @@ void WebView::copySelected()
 {
 	// use native selectedText w/o clipboard hacks.
 	// ideally we should call something like hasSelection() but there is no such method in Qt API for webkit classes.
-	if (page()->hasSelection()) {
+	if (page()->hasSelection() && !page()->selectedText().isEmpty()) {
 		page()->triggerAction(QWebPage::Copy);
 		textCopiedEvent();
 	}


### PR DESCRIPTION
Selection might have zero length. This often happens on a simple click anywhere within webview and removes whatever clipboard was holding at the moment. Also, it emits an irritating "beep", at least on a Mac.