### PR TITLE
Add some guards to X11 calls that cause Psi to crash on Wayland

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -462,6 +462,9 @@ TabbableWidget* findActiveTab()
 
 void x11wmClass(Display *dsp, WId wid, QString resName)
 {
+	if (!QX11Info::isPlatformX11())
+		return;
+
 	//Display *dsp = x11Display();				 // get the display
 	//WId win = winId();						   // get the window
 	XClassHint classhint;						  // class hints
@@ -483,6 +486,9 @@ void x11wmClass(Display *dsp, WId wid, QString resName)
 // Helper function
 bool getCardinal32Prop(Display *display, Window win, char *propName, long *value)
 {
+	if (!QX11Info::isPlatformX11())
+		return false;
+
 	Atom nameAtom, typeAtom, actual_type_return;
 	int actual_format_return, result;
 	unsigned long nitems_return, bytes_after_return;

--- a/src/psiapplication.cpp
+++ b/src/psiapplication.cpp
@@ -265,7 +265,7 @@ void PsiApplication::init(bool GUIenabled)
 #endif
 
 #ifdef HAVE_X11
-	if ( GUIenabled ) {
+	if ( GUIenabled && QX11Info::isPlatformX11() ) {
 		const int max = 20;
 		char* names[max];
 		int n = 0;
@@ -276,7 +276,6 @@ void PsiApplication::init(bool GUIenabled)
 #ifdef HAVE_QT5
 		xcb_atom_t* atoms[max];
 		xcb_intern_atom_cookie_t cookies[max];
-
 
 		_xcbEventFilter = new XcbEventFiter(this);
 		// get the selection type we'll use to locate the notification tray
@@ -351,7 +350,8 @@ void PsiApplication::init(bool GUIenabled)
 bool PsiApplication::notify(QObject *receiver, QEvent *event)
 {
 #ifdef HAVE_X11
-	if( event->type() == QEvent::Show && receiver->isWidgetType())
+	if( event->type() == QEvent::Show && receiver->isWidgetType()
+			&& QX11Info::isPlatformX11())
 	{
 		QWidget* w = static_cast< QWidget* >( receiver );
 		if( w->isTopLevel() && qt_x_last_input_time != CurrentTime ) // CurrentTime means no input event yet
@@ -364,7 +364,8 @@ bool PsiApplication::notify(QObject *receiver, QEvent *event)
 					 32, PropModeReplace, (unsigned char*)&qt_x_last_input_time, 1 );
 #endif
 	}
-	if( event->type() == QEvent::Hide && receiver->isWidgetType())
+	if( event->type() == QEvent::Hide && receiver->isWidgetType()
+			&& QX11Info::isPlatformX11())
 	{
 		QWidget* w = static_cast< QWidget* >( receiver );
 		if( w->isTopLevel() && w->winId() != 0 )

--- a/src/tools/advwidget/advwidget.cpp
+++ b/src/tools/advwidget/advwidget.cpp
@@ -233,61 +233,7 @@ void GAdvancedWidget::Private::doFlash(bool yes)
 	if (parentWidget_->window() != parentWidget_)
 		return;
 
-#ifdef Q_OS_WIN
-	FLASHWINFO fwi;
-	fwi.cbSize = sizeof(fwi);
-	fwi.hwnd = (HWND)parentWidget_->winId();
-	if (yes) {
-		fwi.dwFlags = FLASHW_ALL | FLASHW_TIMER;
-		fwi.dwTimeout = 0;
-		fwi.uCount = 5;
-	}
-	else {
-		fwi.dwFlags = FLASHW_STOP;
-		fwi.uCount = 0;
-	}
-	FlashWindowEx(&fwi);
-
-#elif defined( HAVE_X11 )
-	static Atom demandsAttention = None;
-	static Atom wmState = None;
-
-
-	/* Xlib-based solution */
-	// adopted from http://www.qtforum.org/article/12334/Taskbar-flashing.html
-	// public domain by Marcin Jakubowski
-	Display *xdisplay = QX11Info::display();
-	Window rootwin = QX11Info::appRootWindow();
-
-	if (demandsAttention == None) {
-		demandsAttention = XInternAtom(xdisplay, "_NET_WM_STATE_DEMANDS_ATTENTION", true);
-	}
-	if (wmState == None) {
-		wmState = XInternAtom(xdisplay, "_NET_WM_STATE", true);
-	}
-
-	XEvent e;
-	e.xclient.type = ClientMessage;
-	e.xclient.message_type = wmState;
-	e.xclient.display = xdisplay;
-	e.xclient.window = parentWidget_->winId();
-	e.xclient.format = 32;
-	e.xclient.data.l[1] = demandsAttention;
-	e.xclient.data.l[2] = 0l;
-	e.xclient.data.l[3] = 0l;
-	e.xclient.data.l[4] = 0l;
-
-	if (yes) {
-		e.xclient.data.l[0] = 1;
-	}
-	else {
-		e.xclient.data.l[0] = 0;
-	}
-	XSendEvent(xdisplay, rootwin, False, (SubstructureRedirectMask | SubstructureNotifyMask), &e);
-
-#else
-	Q_UNUSED(yes)
-#endif
+	QApplication::alert(parentWidget_, yes ? 0 : 1);
 }
 
 void GAdvancedWidget::Private::moveEvent(QMoveEvent *)


### PR DESCRIPTION
Also replace doFlash implementation with [QApplication::alert](https://doc.qt.io/qt-5/qapplication.html#alert). Not sure if that is a correct way to do it, though, I guess it needs some testing on different platforms.

This + psi-im/libpsi#9 render Psi usable on Wayland sessions (though some functions like idle won't work)