### PR TITLE
Disable IME (Input Method Editor)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -483,6 +483,12 @@ QStringList getQtPluginPathEnvVar()
 
 int main(int argc, char *argv[])
 {
+	// Disable Input Method Editor to fix bug with
+	//   third-party keyboard layout switching tools
+#if defined(Q_OS_WIN) && defined(WEBENGINE)
+	ImmDisableIME(-1);
+#endif
+
 	// If Psi runs as uri handler the commandline might contain
 	// almost arbitary network supplied data after the "--uri" argument.
 	// To prevent any potentially dangerous options in Psi or

--- a/src/src.pro
+++ b/src/src.pro
@@ -79,6 +79,7 @@ unix {
 
 windows {
 	LIBS += -lWSock32 -lUser32 -lShell32 -lGdi32 -lAdvAPI32
+	qtwebengine { LIBS += -limm32 }
 	DEFINES += QT_STATICPLUGIN
 	DEFINES += NOMINMAX # suppress min/max #defines in windows headers
 	INCLUDEPATH += . # otherwise MSVC will fail to find "common.h" when compiling options/* stuff


### PR DESCRIPTION
Disable IME to fix WebEngine bug causing whole application to hang when using third-party keyboard layout switching tools (such as lswitch or Punto Switcher).