### PR TITLE
Fix detection that a list of contact groups has changed

### DIFF
--- a/src/contactlistmodel.cpp
+++ b/src/contactlistmodel.cpp
@@ -386,8 +386,9 @@ void ContactListModel::Private::contactUpdated()
 	QList<ContactListItem*> groupItems;
 	for (const QPersistentModelIndex &index: monitoredContacts.values(contact)) {
 		ContactListItem *item = q->toItem(index);
-		if (item->parent() && item->parent()->isGroup()) {
-			groupItems << item;
+		ContactListItem *parent = item->parent();
+		if (parent && parent->isGroup()) {
+			groupItems << parent;
 		}
 	}
 


### PR DESCRIPTION
Correctly detect the old list of groups: it must contain contact
groups instead of a contact itself.