### PR TITLE
QApplication::alert() replaced with FlashWindowEx() for Windows systems.

### DIFF
--- a/src/tools/advwidget/advwidget.cpp
+++ b/src/tools/advwidget/advwidget.cpp
@@ -232,8 +232,31 @@ void GAdvancedWidget::Private::doFlash(bool yes)
 	flashing_ = yes;
 	if (parentWidget_->window() != parentWidget_)
 		return;
-
+	
+#ifdef Q_OS_WIN
+	
+	FLASHWINFO fwi;
+	
+	fwi.cbSize = sizeof(fwi);
+	fwi.hwnd = (HWND)parentWidget_->winId();
+	
+	if (yes) {
+		fwi.dwFlags = FLASHW_ALL | FLASHW_TIMER;
+		fwi.dwTimeout = 0;
+		fwi.uCount = 5;
+	}
+	else {
+		fwi.dwFlags = FLASHW_STOP;
+		fwi.uCount = 0;
+	}
+	
+	FlashWindowEx(&fwi);
+	
+#else
+	
 	QApplication::alert(parentWidget_, yes ? 0 : 1);
+	
+#endif
 }
 
 void GAdvancedWidget::Private::moveEvent(QMoveEvent *)


### PR DESCRIPTION
QApplication::alert() replaced with FlashWindowEx() only for Windows due to instability, for all other systems it remains unchanged.