### PR TITLE
fix Qt version detection

### DIFF
--- a/configure
+++ b/configure
@@ -402,7 +402,7 @@ qmake_check() {
 		fi
 		vout=`/bin/sh -c "$cmd" 2>&1`
 		case "${vout}" in
-			?.?.?)
+			*.*.*)
 				vmaj="${vout%%.*}"
 				if [ ! -z "$QC_QTSELECT" ]; then
 					if [ "$vmaj" = "$QC_QTSELECT" ]; then


### PR DESCRIPTION
Previous code will fail for Qt version "5.10.x". This updates the
code to use qconf's method.