### PR TITLE
Set tab to inactive color when the contact is in inactive state

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -412,6 +412,7 @@ QLineEdit#le_status_text {
                     <chat>
                         <composing-color type="QColor">darkGreen</composing-color>
                         <unread-message-color type="QColor">red</unread-message-color>
+                        <inactive-color type="QColor">grey</inactive-color>
                     </chat>
                     <passive-popup>
                         <border type="QColor">#5297f9</border>

--- a/src/chatdlg.cpp
+++ b/src/chatdlg.cpp
@@ -281,9 +281,9 @@ bool ChatDlg::readyToHide()
 
     // Reset 'contact is composing' & cancel own composing event
     resetComposing();
-    setChatState(StateGone);
+    setChatState(XMPP::StateGone);
     if (contactChatState_ == XMPP::StateComposing || contactChatState_ == XMPP::StateInactive) {
-        setContactChatState(StatePaused);
+        setContactChatState(XMPP::StatePaused);
     }
 
     if (pending_ > 0) {
@@ -312,7 +312,7 @@ void ChatDlg::hideEvent(QHideEvent* e)
 {
     if (isMinimized()) {
         resetComposing();
-        setChatState(StateInactive);
+        setChatState(XMPP::StateInactive);
     }
     TabbableWidget::hideEvent(e);
 }
@@ -704,7 +704,7 @@ QString ChatDlg::desiredCaption() const
     if (contactChatState_ == XMPP::StateComposing) {
         cap = tr("%1 (Composing ...)").arg(cap);
     }
-    else if (contactChatState_ == XMPP::StateInactive) {
+    else if (contactChatState_ == XMPP::StateInactive || contactChatState_ == XMPP::StateGone) {
         cap = tr("%1 (Inactive)").arg(cap);
     }
 
@@ -1250,9 +1250,15 @@ void ChatDlg::chatEditCreated()
 
 TabbableWidget::State ChatDlg::state() const
 {
-    return contactChatState_ == XMPP::StateComposing ?
-           TabbableWidget::StateComposing :
-           TabbableWidget::StateNone;
+    switch (contactChatState_) {
+        case XMPP::StateComposing:
+            return TabbableWidget::StateComposing;
+        case XMPP::StateInactive:
+        case XMPP::StateGone:
+            return TabbableWidget::StateInactive;
+        default:
+            return TabbableWidget::StateNone;
+    }
 }
 
 int ChatDlg::unreadMessageCount() const

--- a/src/tabs/tabbablewidget.h
+++ b/src/tabs/tabbablewidget.h
@@ -63,7 +63,8 @@ public:
 
     enum State {
         StateNone = 0,
-        StateComposing
+        StateComposing,
+        StateInactive
     };
     virtual State state() const = 0;
     virtual int unreadMessageCount() const = 0;

--- a/src/tabs/tabdlg.cpp
+++ b/src/tabs/tabdlg.cpp
@@ -564,6 +564,8 @@ QString TabDlg::desiredCaption() const
             cap += qobject_cast<TabbableWidget*>(tabWidget_->currentPage())->getDisplayName();
             if (qobject_cast<TabbableWidget*>(tabWidget_->currentPage())->state() == TabbableWidget::StateComposing) {
                 cap += tr(" is composing");
+            } else if (qobject_cast<TabbableWidget*>(tabWidget_->currentPage())->state() == TabbableWidget::StateInactive) {
+                cap = tr("%1 (Inactive)").arg(cap);
             }
         }
     }
@@ -648,6 +650,10 @@ void TabDlg::updateTab(TabbableWidget* chat)
     else if (chat->unreadMessageCount()) {
         tabWidget_->setTabTextColor(chat, PsiOptions::instance()->getOption("options.ui.look.colors.chat.unread-message-color").value<QColor>());
         tabWidget_->setTabIcon(chat, IconsetFactory::iconPtr("psi/chat")->icon());
+    }
+    else if (chat->state() == TabbableWidget::StateInactive) {
+        tabWidget_->setTabTextColor(chat, PsiOptions::instance()->getOption("options.ui.look.colors.chat.inactive-color").value<QColor>());
+        tabWidget_->setTabIcon(chat, chat->icon());
     }
     else {
         tabWidget_->setTabTextColor(chat, palette().color(QPalette::Text));


### PR DESCRIPTION
Fixes the disparity between various Psi modes. In non-tabbed mode,
the "(Inactive)" suffix is added to the window title. In tabbed mode,
there was no suffix. However, adding the suffix alone was not enough,
because in the all-in-one mode there is no window title displayed.

Also, Gone status is now regarded as inactive too.