### PR TITLE
HiDPI tweaks for displaying avatars

### DIFF
--- a/src/contactlistviewdelegate.cpp
+++ b/src/contactlistviewdelegate.cpp
@@ -546,7 +546,7 @@ QPixmap ContactListViewDelegate::Private::avatarIcon(const QModelIndex &index)
     if(av.isNull() && useDefaultAvatar_)
         av = IconsetFactory::iconPixmap("psi/default_avatar");
 
-    return AvatarFactory::roundedAvatar(av, avatarRadius_, avSize);
+    return AvatarFactory::roundedAvatar(av, avatarRadius_ * devicePixelRatio(contactList), avSize * devicePixelRatio(contactList));
 
 }
 

--- a/src/gcuserview.cpp
+++ b/src/gcuserview.cpp
@@ -52,8 +52,9 @@ class GCUserViewDelegate : public QItemDelegate
 {
     Q_OBJECT
 public:
-    GCUserViewDelegate(QObject* p)
+    GCUserViewDelegate(QWidget* p)
         : QItemDelegate(p)
+        , list_(p)
     {
         updateSettings();
     }
@@ -156,10 +157,10 @@ public:
             if(ava.isNull()) {
                 ava = IconsetFactory::iconPixmap("psi/default_avatar");
             }
-            ava = AvatarFactory::roundedAvatar(ava, avatarRadius_, avatarSize_);
+            ava = AvatarFactory::roundedAvatar(ava, avatarRadius_ * devicePixelRatio(list_), avatarSize_ * devicePixelRatio(list_));
             QRect avaRect(rect);
-            avaRect.setWidth(ava.width());
-            avaRect.setHeight(ava.height());
+            avaRect.setWidth(ava.width() / devicePixelRatio(list_));
+            avaRect.setHeight(ava.height() / devicePixelRatio(list_));
             if(!avatarAtLeft_) {
                 avaRect.moveTopRight(rect.topRight());
                 avaRect.translate(-1, 1);
@@ -274,6 +275,7 @@ private:
     QColor colorForeground_, colorBackground_, colorModerator_, colorParticipant_, colorVisitor_, colorNoRole_;
     bool showGroups_, slimGroups_, nickColoring_, showClients_, showAffiliations_, showStatusIcons_, showAvatar_, avatarAtLeft_;
     int avatarSize_, fontHeight_, avatarRadius_;
+    QWidget *list_;
 };
 
 

--- a/src/psichatdlg.cpp
+++ b/src/psichatdlg.cpp
@@ -749,7 +749,9 @@ void PsiChatDlg::updateAvatar()
     int avatarSize = p.width(); //qMax(p.width(), p.height());
     if (avatarSize > optSize)
         avatarSize = optSize;
-    ui_.avatar->setPixmap(p.scaled(QSize(avatarSize, avatarSize), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    QPixmap scaled = p.scaled(QSize(avatarSize * ::devicePixelRatio(this), avatarSize * ::devicePixelRatio(this)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    scaled.setDevicePixelRatio(::devicePixelRatio(this));
+    ui_.avatar->setPixmap(scaled);
     ui_.avatar->show();
 }
 

--- a/src/psipopup.cpp
+++ b/src/psipopup.cpp
@@ -180,7 +180,9 @@ QBoxLayout *PsiPopup::Private::createContactInfo(const QPixmap *avatar, const Ps
         int size = PsiOptions::instance()->getOption("options.ui.notifications.passive-popups.avatar-size").toInt();
         QLabel *avatarLabel = new QLabel(popup);
         avatarLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
-        avatarLabel->setPixmap(avatar->scaled(QSize(size, size), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+        QPixmap av = avatar->scaled(QSize(size * devicePixelRatio(avatarLabel), size * devicePixelRatio(avatarLabel)), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        av.setDevicePixelRatio(devicePixelRatio(avatarLabel));
+        avatarLabel->setPixmap(av);
         dataBox->addWidget(avatarLabel);
         dataBox->addSpacing(5);
     }

--- a/src/rosteravatarframe.cpp
+++ b/src/rosteravatarframe.cpp
@@ -22,7 +22,7 @@
 #include "psioptions.h"
 #include "iconset.h"
 #include "qpainter.h"
-
+#include "common.h"
 
 RosterAvatarFrame::RosterAvatarFrame(QWidget *parent)
     : QFrame(parent)
@@ -66,12 +66,12 @@ void RosterAvatarFrame::setActivityIcon(const QString &activity)
 
 void RosterAvatarFrame::drawAvatar()
 {
-    int avSize = PsiOptions::instance()->getOption("options.ui.contactlist.roster-avatar-frame.avatar.size").toInt();
+    int avSize = PsiOptions::instance()->getOption("options.ui.contactlist.roster-avatar-frame.avatar.size").toInt() * ::devicePixelRatio(this);
     QPixmap av = avatarPixmap;
     if(!av.isNull()) {
-        int radius = PsiOptions::instance()->getOption("options.ui.contactlist.avatars.radius").toInt();
+        int radius = PsiOptions::instance()->getOption("options.ui.contactlist.avatars.radius").toInt() * ::devicePixelRatio(this);
         if(!radius)
-            av = av.scaled(avSize,avSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            av = av.scaled(avSize, avSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         else {
             avSize = qMax(avSize, radius*2);
             av = av.scaled(avSize, avSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
@@ -87,8 +87,9 @@ void RosterAvatarFrame::drawAvatar()
             av = avatar_icon;
         }
     }
+    av.setDevicePixelRatio(::devicePixelRatio(this));
     ui_.lb_avatar->setPixmap(av);
-    ui_.lb_avatar->setFixedSize(avSize,avSize);
+    ui_.lb_avatar->setFixedSize(avSize / ::devicePixelRatio(this), avSize / ::devicePixelRatio(this));
 }
 
 void RosterAvatarFrame::setStatusIcon(const QIcon &ico)


### PR DESCRIPTION
#350

Icons are untouched yet, will probably need changes to icon system... but icons aren't that important, avatars are!
Tooltips are still pixelated - don't know what to do with them, there doesn't seem to be a way to control device pixel ratio for <img>s inside richtext tooltips. It might need generation of @2x files in avatar cache, but I haven't tried it yet.

Anyway, roster, popups, muc user list and message window all seem to be handled properly now :)