### PR TITLE
Do not destroy window's contents on hiding it via 'close' button

### DIFF
--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -1437,11 +1437,12 @@ void MainWin::closeEvent(QCloseEvent* e)
 
     if(d->tray && !quitOnClose) {
         trayHide();
-        e->accept();
+        e->ignore();
         return;
     }
 
     if(!askQuit()) {
+        e->ignore();
         return;
     }
 


### PR DESCRIPTION
With Qt 5.11, when tray is enabled and application is configured not to quit on contacts list closing, if contacts list window (main window) is closed via 'close' button on window's header, and after that shown again using tray icon, reappearing window is empty.

This change fixes the issue by properly ignoring 'close' event if there's no intention to permanently close the window. Window is properly hidden via 'trayHide()' function.

Line change after 'askQuit()' function should lead to same result in case this function is implemented.

Issue is reproduced on Linux with Qt 5.11.2. It probably may be reproduced on Windows with Qt >=5.11 too.