### PR TITLE
Change headers inclusion order

### DIFF
--- a/src/chatview_te.h
+++ b/src/chatview_te.h
@@ -20,14 +20,14 @@
 #ifndef CHATVIEW_TE_H
 #define CHATVIEW_TE_H
 
+#include "chatviewcommon.h"
+#include "psitextview.h"
+#include "xmpp/jid/jid.h"
+
 #include <QContextMenuEvent>
 #include <QDateTime>
 #include <QPointer>
 #include <QWidget>
-
-#include "chatviewcommon.h"
-#include "psitextview.h"
-#include "xmpp/jid/jid.h"
 
 class ChatEdit;
 class ChatViewBase;

--- a/src/chatview_webkit.h
+++ b/src/chatview_webkit.h
@@ -20,13 +20,13 @@
 #ifndef CHATVIEW_WEBKIT_H
 #define CHATVIEW_WEBKIT_H
 
+#include "chatviewcommon.h"
+#include "webview.h"
+
 #include <QDateTime>
 #include <QFrame>
 #include <QPointer>
 #include <QWidget>
-
-#include "chatviewcommon.h"
-#include "webview.h"
 
 class ChatEdit;
 class ChatView;

--- a/src/chatviewcommon.cpp
+++ b/src/chatviewcommon.cpp
@@ -17,15 +17,14 @@
  *
  */
 
+#include "chatviewcommon.h"
+
 #include "psioptions.h"
 
 #include <QApplication>
-#include <QColor>
 #include <QRegExp>
 #include <QWidget>
 #include <math.h>
-
-#include "chatviewcommon.h"
 
 void ChatViewCommon::setLooks(QWidget *w)
 {

--- a/src/chatviewcommon.h
+++ b/src/chatviewcommon.h
@@ -20,6 +20,7 @@
 #ifndef CHATVIEWBASE_H
 #define CHATVIEWBASE_H
 
+#include <QColor>
 #include <QDateTime>
 #include <QMap>
 #include <QStringList>

--- a/src/contactmanager/contactmanagerdlg.cpp
+++ b/src/contactmanager/contactmanagerdlg.cpp
@@ -20,13 +20,12 @@
 #include "contactmanagerdlg.h"
 
 //#include "contactview.h"
-#include "xmpp_client.h"
-#include "xmpp_tasks.h"
-
 #include "psiaccount.h"
 #include "psiiconset.h"
 #include "userlist.h"
 #include "vcardfactory.h"
+#include "xmpp_client.h"
+#include "xmpp_tasks.h"
 
 #include <QCheckBox>
 #include <QFile>

--- a/src/pluginhost.cpp
+++ b/src/pluginhost.cpp
@@ -5,19 +5,6 @@
 
 #include "pluginhost.h"
 
-#include <QAction>
-#include <QByteArray>
-#include <QDomElement>
-#include <QKeySequence>
-#include <QObject>
-#include <QPluginLoader>
-#include <QRegExp>
-#include <QSplitter>
-#include <QString>
-#include <QStringList>
-#include <QTextEdit>
-#include <QWidget>
-
 #include "accountinfoaccessor.h"
 #include "activetabaccessor.h"
 #include "applicationinfo.h"
@@ -56,6 +43,19 @@
 #include "webkitaccessor.h"
 #include "widgets/iconaction.h"
 //#include "xmpp_message.h"
+
+#include <QAction>
+#include <QByteArray>
+#include <QDomElement>
+#include <QKeySequence>
+#include <QObject>
+#include <QPluginLoader>
+#include <QRegExp>
+#include <QSplitter>
+#include <QString>
+#include <QStringList>
+#include <QTextEdit>
+#include <QWidget>
 
 /**
  * \brief Constructs a host/wrapper for a plugin.

--- a/src/pluginhost.h
+++ b/src/pluginhost.h
@@ -6,13 +6,6 @@
 #ifndef PLUGINHOST_H
 #define PLUGINHOST_H
 
-#include <QDomElement>
-#include <QMultiMap>
-#include <QPointer>
-#include <QRegExp>
-#include <QTextEdit>
-#include <QVariant>
-
 #include "accountinfoaccessinghost.h"
 #include "activetabaccessinghost.h"
 #include "applicationinfo.h"
@@ -35,6 +28,13 @@
 #include "tabdlg.h"
 #include "userlist.h"
 #include "webkitaccessinghost.h"
+
+#include <QDomElement>
+#include <QMultiMap>
+#include <QPointer>
+#include <QRegExp>
+#include <QTextEdit>
+#include <QVariant>
 
 class IqNamespaceFilter;
 class PluginManager;

--- a/src/rc.cpp
+++ b/src/rc.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "rc.h"
+
 #include "ahcommand.h"
 #include "ahcservermanager.h"
 #include "groupchatdlg.h"

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -1,11 +1,11 @@
-#include <QTextDocument> // for escape()
-
 #include "textutil.h"
 
 #include "coloropt.h"
 #include "psiiconset.h"
 #include "psioptions.h"
 #include "rtparse.h"
+
+#include <QTextDocument> // for escape()
 
 QString TextUtil::escape(const QString &plain) { return plain.toHtmlEscaped(); }
 


### PR DESCRIPTION
Change headers inclusion order
-> A->Z order (clang missing parts)

Move in src/chatview_te.h
#include "chatviewcommon.h"
#include "psitextview.h"
#include "xmpp/jid/jid.h"

Move in src/chatview_webkit.h
#include "chatviewcommon.h"
#include "webview.h"

Move in src/chatviewcommon.cpp
#include "chatviewcommon.h"

Remove in src/chatviewcommon.cpp
#include <QColor>

Add in src/chatviewcommon.h (before in src/chatviewcommon.cpp)
#include <QColor>

Move in src/contactmanager/contactmanagerdlg.cpp
#include "xmpp_client.h"
#include "xmpp_tasks.h"

Move in src/pluginhost.cpp
#include <QAction>
#include <QByteArray>
#include <QDomElement>
#include <QKeySequence>
#include <QObject>
#include <QPluginLoader>
#include <QRegExp>
#include <QSplitter>
#include <QString>
#include <QStringList>
#include <QTextEdit>
#include <QWidget>

Move in src/pluginhost.h
#include <QDomElement>
#include <QMultiMap>
#include <QPointer>
#include <QRegExp>
#include <QTextEdit>
#include <QVariant>

Add a line in src/rc.cpp

Move in src/textutil.cpp
#include <QTextDocument> // for escape() 