### PR TITLE
Add the mucNick() function to the plugins API

### DIFF
--- a/plugins/include/contactinfoaccessinghost.h
+++ b/plugins/include/contactinfoaccessinghost.h
@@ -22,6 +22,7 @@ public:
     virtual QString     statusMessage(int account, const QString &jid)                    = 0;
     virtual QStringList resources(int account, const QString &jid)                        = 0;
     virtual QString     realJid(int account, const QString &jid)                          = 0;
+    virtual QString     mucNick(int account, const QString &mucJid)                       = 0;
     virtual QStringList mucNicks(int account, const QString &mucJid)                      = 0;
     virtual bool        hasCaps(int account, const QString &jid, const QStringList &caps) = 0;
 };

--- a/src/pluginhost.cpp
+++ b/src/pluginhost.cpp
@@ -1297,6 +1297,8 @@ QStringList PluginHost::resources(int account, const QString &jid) { return mana
 
 QString PluginHost::realJid(int account, const QString &jid) { return manager_->realJid(account, jid); }
 
+QString PluginHost::mucNick(int account, const QString &mucJid) { return manager_->mucNick(account, mucJid); }
+
 QStringList PluginHost::mucNicks(int account, const QString &mucJid) { return manager_->mucNicks(account, mucJid); }
 
 bool PluginHost::hasCaps(int account, const QString &jid, const QStringList &caps)

--- a/src/pluginhost.h
+++ b/src/pluginhost.h
@@ -194,6 +194,7 @@ public:
     QString     statusMessage(int account, const QString &jid) override;
     QStringList resources(int account, const QString &jid) override;
     QString     realJid(int account, const QString &jid) override;
+    QString     mucNick(int account, const QString &mucJid) override;
     QStringList mucNicks(int account, const QString &mucJid) override;
     bool        hasCaps(int account, const QString &jid, const QStringList &caps) override;
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1198,6 +1198,18 @@ QString PluginManager::realJid(int account, const QString &jid) const
     return jid;
 }
 
+QString PluginManager::mucNick(int account, const QString &mucJid) const
+{
+    PsiAccount *acc = accountIds_.account(account);
+    if (acc) {
+      auto gcDlg = acc->findDialog<GCMainDlg *>(mucJid);
+      if (gcDlg) {
+        return gcDlg->nick();
+      }
+    }
+    return "";
+}
+
 QStringList PluginManager::mucNicks(int account, const QString &mucJid) const
 {
     PsiAccount *acc = accountIds_.account(account);

--- a/src/pluginmanager.h
+++ b/src/pluginmanager.h
@@ -187,6 +187,7 @@ private:
     QString     statusMessage(int account, const QString &jid) const;
     QStringList resources(int account, const QString &jid) const;
     QString     realJid(int account, const QString &jid) const;
+    QString     mucNick(int account, const QString &mucJid) const;
     QStringList mucNicks(int account, const QString &mucJid) const;
     bool        hasCaps(int account, const QString &jid, const QStringList &caps);
 


### PR DESCRIPTION
Related to psi-im/plugins#94, this pull request adds the `mucNick(int account, const QString &mucJid)` function which retrieves the account's nickname in specified MUC.