### PR TITLE
README.md: install --cask instead of cask install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GNU/Linux and FreeBSD users may install [packages](https://github.com/psi-im/psi
 macOS users may install and update official builds using [Homebrew](https://brew.sh/) cask:
 
 ```
-brew cask install psi-plus
+brew install --cask psi-plus
 ```
 
 or download app bundles from [SourceForge](https://github.com/psi-im/psi#packages-and-installers) and install them manually. Program doesn't have embedded mechanism of updates, so in this case users should monitor updates themselves.


### PR DESCRIPTION
With "cask install" brew returns an error.

<img width="413" alt="Screen Shot 2021-11-08 at 14 31 55" src="https://user-images.githubusercontent.com/93676716/140791004-4b44cdcb-15e3-4fbe-9faa-6cb9dc460f48.png">
