### PR TITLE
gchat_templates -> chat_templates

### DIFF
--- a/src/psioptions.cpp
+++ b/src/psioptions.cpp
@@ -177,7 +177,7 @@ bool PsiOptions::newProfile()
                          << "chat_voice"
                          << "chat_share_files"
                          << "chat_active_contacts"
-                         << "gchat_templates";
+                         << "chat_templates";
 
         ToolbarPrefs groupchatToolbar;
         groupchatToolbar.on   = true;


### PR DESCRIPTION
There is a problem in the code, currently it is gchat_templates but it is not for groupchat but for chat, I replace to chat_templates.

One PR by solution, to be clear in timeline :)