### PR TITLE
Allow proper runtime linking with `pkgin`-installed libraries on NetBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,8 @@ endif()
 STRING (REGEX MATCH "NetBSD" PROJECT_OS_NETBSD ${CMAKE_SYSTEM_NAME})
 if(PROJECT_OS_BSD)
 	message(STATUS "NetBSD detected")
-	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib")
-	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib")
+	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib")
+	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib")
 endif()
 
 # Qt dependencies make building very slow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,8 @@ endif()
 STRING (REGEX MATCH "NetBSD" PROJECT_OS_NETBSD ${CMAKE_SYSTEM_NAME})
 if(PROJECT_OS_BSD)
 	message(STATUS "NetBSD detected")
-	link_directories(/usr/X11R7/lib)
+	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib")
+	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib")
 endif()
 
 # Qt dependencies make building very slow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,13 @@ if(PROJECT_OS_BSD)
     add_definitions(-DIOAPI_NO_64)
 endif()
 
+# Detect NetBSD and handle library path accordingly
+STRING (REGEX MATCH "NetBSD" PROJECT_OS_NETBSD ${CMAKE_SYSTEM_NAME})
+if(PROJECT_OS_BSD)
+	message(STATUS "NetBSD detected")
+	link_directories(/usr/X11R7/lib)
+endif()
+
 # Qt dependencies make building very slow
 # Track only .h files
 include_regular_expression("^.*\\.h$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,8 @@ endif()
 STRING (REGEX MATCH "NetBSD" PROJECT_OS_NETBSD ${CMAKE_SYSTEM_NAME})
 if(PROJECT_OS_BSD)
 	message(STATUS "NetBSD detected")
-	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib")
-	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib")
+	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib -Wl,-rpath,/usr/pkg/qt5/lib")
+	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib -Wl,-rpath,/usr/pkg/qt5/lib")
 endif()
 
 # Qt dependencies make building very slow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ endif()
 
 # Detect NetBSD and handle library path accordingly
 STRING (REGEX MATCH "NetBSD" PROJECT_OS_NETBSD ${CMAKE_SYSTEM_NAME})
-if(PROJECT_OS_BSD)
+if(PROJECT_OS_NETBSD)
 	message(STATUS "NetBSD detected")
 	set(CMAKE_C_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib -Wl,-rpath,/usr/pkg/qt5/lib")
 	set(CMAKE_CXX_FLAGS "-Wl,-rpath,/usr/X11R7/lib -Wl,-rpath,/usr/pkg/lib -Wl,-rpath,/usr/pkg/qt5/lib")


### PR DESCRIPTION
The NetBSD runtime linker appears to look in the same places as the dynamic linker on other systems but does not search LD_LIBRARY_PATH like it does on others, in what appears to be a deliberate design decision. Whatever the case, in order to prevent a `pkgin` user needing to symlink tons of libraries from the `/usr/X11R7` and `/usr/pkg` trees into `/usr/local/lib`, Psi should tell the compiler to include parameters for the runtime linker to find the necessary libraries on that system. To aid in portability, I have created some conditions in CMakeLists.txt to allow for setting the `CFLAGS`/`CXXFLAGS` variables with the appropriate parameters.

I have done minimal testing on NetBSD-9.1 amd64, and it builds successfully and runs correctly with these flags set (where it would build successfully but fail to link at runtime before). I have not thoroughly tested the program's functionality but it does start and show the UI.

Though it shouldn't matter much, I should note that I only build Psi+ (I haven't used base Psi in quite a few years now). If anyone else wishes to test regular Psi builds your input would be appreciated.