### PR TITLE
Make the build reproducible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,8 +154,8 @@ else()
 endif()
 
 #Prepare and generate config.h file
-string(TIMESTAMP PSI_COMPILATION_DATE "%Y-%m-%d")
-string(TIMESTAMP PSI_COMPILATION_TIME "%H:%M:%S")
+string(TIMESTAMP PSI_COMPILATION_DATE "%Y-%m-%d" UTC)
+string(TIMESTAMP PSI_COMPILATION_TIME "%H:%M:%S" UTC)
 
 if(IS_WEBKIT)
     set(PSI_VER_SUFFIX ", webkit")


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort I noticed that psi could not be built reproducibly.

This is due to using CMake's `TIMESTAMP` feature without specifying a timezone. This means that, even if `SOURCE_DATE_EPOCH` is present, the value (and thus the binary) will vary depending on the build machine's timezone setting.

(I originally filed this in Debian as bug [#1017473](https://bugs.debian.org/1017473).)