### PR TITLE
fix uint_32_t build error

### DIFF
--- a/src/widgets/emojiregistry.cpp
+++ b/src/widgets/emojiregistry.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include <cstdint>
+
 #include "emojiregistry.h"
 #include "emojidb.cpp"
 


### PR DESCRIPTION
Fix this:
```
src/widgets/emojiregistry.cpp:40:10: error: 'uint32_t' is not a member of 'std'
```
by including proper header.