### PR TITLE
Remove default global Ctrl+Alt+B "boss-key" binding

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -665,7 +665,7 @@ QLineEdit#le_status_text {
                 <toggle-visibility type="QKeySequence" comment="Show/hide the application"/>
                 <bring-to-front type="QKeySequence" comment="Bring the application to front"/>
                 <new-blank-message type="QKeySequence" comment="Send new message"/>
-                <boss-key type="QKeySequence" comment="Hide all active windows">Ctrl+Alt+B</boss-key>
+                <boss-key type="QKeySequence" comment="Hide all active windows"></boss-key>
             </global>
             <message comment="Shortcuts in the message dialog">
                 <send type="QVariantList" comment="Send the message">


### PR DESCRIPTION
Just a suggestion, but if you think #734 is worth doing, this might save you a click.
Closes #734.