### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ There are a lot of people who were involved into Psi and Psi+ development. Some 
 
 ### Bug reports
 
-If you found a bug please report about it in our [Bug Tracker](https://github.com/psi-im/psi/issues). If you have doubts contact with us in [XMPP Conference](https://chatlogs.jabber.ru/psi-dev@conference.jabber.ru) &lt;psi-dev@conference.jabber.ru&gt; (preferable) or in a [Mailing List](https://groups.google.com/forum/#!forum/psi-users).
+If you found a bug please report about it in our [Bug Tracker](https://github.com/psi-im/psi/issues). If you have doubts contact with us in XMPP Conference [psi-dev@conference.jabber.ru](xmpp:psi-dev@conference.jabber.ru?join) (preferable) or in a [Mailing List](https://groups.google.com/forum/#!forum/psi-users).
 
 ### Beta testing
 
@@ -94,7 +94,7 @@ As we (intentionally) do not have nor beta versions of Psi, nor daily build buil
 
 ### Comments and wishes
 
-We like constructive comments and wishes to functions of program. You may contact with us in [XMPP Conference](https://chatlogs.jabber.ru/psi-dev@conference.jabber.ru) &lt;psi-dev@conference.jabber.ru&gt; for discussing of your ideas. Some of them will be drawn up as feature requests in our [Bug Tracker](https://github.com/psi-im/psi/issues).
+We like constructive comments and wishes to functions of program. You may contact with us in XMPP Conference [psi-dev@conference.jabber.ru](xmpp:psi-dev@conference.jabber.ru?join) for discussing of your ideas. Some of them will be drawn up as feature requests in our [Bug Tracker](https://github.com/psi-im/psi/issues).
 
 ### Translations
 


### PR DESCRIPTION
Add "xmpp:" to the beginning of XMPP links since GitHub puts "mailto:" here by default.

Remove broken links to chatlogs.jabber.ru.