### PR TITLE
NetBSD is supported

### DIFF
--- a/README.html
+++ b/README.html
@@ -9,7 +9,7 @@ Sources: https://github.com/psi-im</p>
 
 <h2>Description</h2>
 
-<p>Psi is an XMPP client designed for experienced users. It is highly portable and runs on GNU/Linux, MS Windows, macOS, FreeBSD and Haiku.</p>
+<p>Psi is an XMPP client designed for experienced users. It is highly portable and runs on GNU/Linux, MS Windows, macOS, FreeBSD, NetBSD and Haiku.</p>
 
 <p>User interface of program is very flexible in customization. For example, there are "multi windows" and "all in one" modes, support of different iconsets and themes. Psi supports file sharing and audio/video calls. Security is also a major consideration, and Psi provides it for both client-to-server (TLS) and client-to-client (OpenPGP, OTR, OMEMO) via appropriate plugins.</p>
 
@@ -32,7 +32,7 @@ Sources: https://github.com/psi-im</p>
 
 <p>For build from sources see <a href="https://github.com/psi-im/psi/blob/master/INSTALL.md">INSTALL</a> file.</p>
 
-<p>GNU/Linux and FreeBSD users may install <a href="https://github.com/psi-im/psi#packages-and-installers">packages</a> from official and unofficial repositories, ports, etc.</p>
+<p>GNU/Linux and *BSD users may install <a href="https://github.com/psi-im/psi#packages-and-installers">packages</a> from official and unofficial repositories, ports, etc.</p>
 
 <p>macOS users may install and update official builds using <a href="https://brew.sh/">Homebrew</a> cask:</p>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This program is licensed under the GNU General Public License. See the [COPYING]
 
 ## Description
 
-Psi is an XMPP client designed for experienced users. It is highly portable and runs on GNU/Linux, MS Windows, macOS, FreeBSD and Haiku.
+Psi is an XMPP client designed for experienced users. It is highly portable and runs on GNU/Linux, MS Windows, macOS, FreeBSD, NetBSD and Haiku.
 
 User interface of program is very flexible in customization. For example, there are "multi windows" and "all in one" modes, support of different iconsets and themes. Psi supports file sharing and audio/video calls. Security is also a major consideration, and Psi provides it for both client-to-server (TLS) and client-to-client (OpenPGP, OTR, OMEMO) via appropriate plugins.
 
@@ -30,7 +30,7 @@ See [CHANGELOG](https://github.com/psi-im/psi/blob/master/CHANGELOG) file.
 
 For build from sources see [INSTALL](https://github.com/psi-im/psi/blob/master/INSTALL.md) file.
 
-GNU/Linux and FreeBSD users may install [packages](https://github.com/psi-im/psi#packages-and-installers) from official and unofficial repositories, ports, etc.
+GNU/Linux and *BSD users may install [packages](https://github.com/psi-im/psi#packages-and-installers) from official and unofficial repositories, ports, etc.
 
 macOS users may install and update official builds using [Homebrew](https://brew.sh/) cask:
 

--- a/psi.doap
+++ b/psi.doap
@@ -31,6 +31,7 @@
     <os>Linux</os>
     <os>macOS</os>
     <os>FreeBSD</os>
+    <os>NetBSD</os>
     <os>Windows</os>
     <os>Haiku</os>
 


### PR DESCRIPTION
Psi 1.5 is in the official binary package repository and works fine. Just installed NetBSD in a QEMU VM to test it.

https://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/chat/psi/index.html