### PR TITLE
Fix alerts for already open chats

### DIFF
--- a/src/psiaccount.cpp
+++ b/src/psiaccount.cpp
@@ -5208,7 +5208,7 @@ void PsiAccount::handleEvent(const PsiEvent::Ptr &e, ActivationType activationTy
             if (c && (d->tabManager->isChatTabbed(c) || !c->isHidden())) {
                 c->incomingMessage(m);
                 soundType = eChat2;
-                if (selfMessage
+                if (!selfMessage
                     && ((o->getOption("options.ui.chat.alert-for-already-open-chats").toBool() && !c->isActiveTab())
                         || (c->isTabbed() && c->getManagingTabDlg()->isHidden()))) {
 


### PR DESCRIPTION
Commit cf33bcda6ca18fbac2cfff5292a92bec1a195d51 accidentally inverted the logic for when to notify already open chats from "notify when message is not coming from own clients" to "notify when message IS coming from own clients".