### PR TITLE
Disable user join and leave notifiations by default

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -46,7 +46,7 @@
             <bookmarks comment="Options for bookmarked conference rooms">
                 <auto-join comment="Automatically join bookmarked conference rooms that are configured for auto-joining." type="bool">true</auto-join>
             </bookmarks>
-            <show-joins comment="Display notices of users joining and leaving conferences" type="bool">true</show-joins>
+            <show-joins comment="Display notices of users joining and leaving conferences" type="bool">false</show-joins>
             <show-role-affiliation comment="Include role and affiliation changes in join messages, and display notices of changes" type="bool">true</show-role-affiliation>
             <show-status-changes comment="Show status changes in groupchat window" type="bool">false</show-status-changes>
             <accept-defaults comment="Automatically accept the default room configuration when a new room is created." type="bool">true</accept-defaults>


### PR DESCRIPTION
When you have a large room with many users who are on mobile internet then this messages floods all the chat history. Probably this notifications made some sense in old days but now this needs to be changed.
The problem is that we have two separate events that XMPP doesn't allow to distinguish:

* A user joins a chat i.e. this is a completely new participant (which happens rarely)
* A user become available now and he will probably read your message if you write in the chat (it's not that important). Maybe for small rooms with a few participants this is needed sometimes.

Generally speaking this is something that needs to be discussed with other clients or at least with Modern XMPP project https://github.com/modernxmpp/modernxmpp/issues/65.

I would like to propose to disable this notification by default. If needed a user can open Options / Advanced / Filter `options.muc.show-joins` and change the `False` to `True`.