### PR TITLE
Simplify status message usage

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -741,10 +741,10 @@ QLineEdit#le_status_text {
         <status>
             <ask-for-message-on-offline type="bool">false</ask-for-message-on-offline>
             <ask-for-message-on-online type="bool">false</ask-for-message-on-online>
-            <ask-for-message-on-chat type="bool">true</ask-for-message-on-chat>
-            <ask-for-message-on-away type="bool">true</ask-for-message-on-away>
+            <ask-for-message-on-chat type="bool">false</ask-for-message-on-chat>
+            <ask-for-message-on-away type="bool">false</ask-for-message-on-away>
             <ask-for-message-on-xa type="bool">true</ask-for-message-on-xa>
-            <ask-for-message-on-dnd type="bool">true</ask-for-message-on-dnd>
+            <ask-for-message-on-dnd type="bool">false</ask-for-message-on-dnd>
             <auto-away>
                 <away-after type="int">10</away-after>
                 <force-priority type="bool">false</force-priority>

--- a/src/statusdlg.cpp
+++ b/src/statusdlg.cpp
@@ -43,6 +43,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QVBoxLayout>
+#include <QTimer>
 
 //----------------------------------------------------------------------------
 // StatusShowDlg
@@ -220,6 +221,13 @@ void StatusSetDlg::init()
     ShortcutManager::connect("common.close", this, SLOT(close()));
     ShortcutManager::connect("status.set", this, SLOT(doButton()));
 
+    // Give to a user 5s to type status and if not then just apply the empty
+    QTimer::singleShot(5000, this, [this]() {
+        // if user didn't started typing the status
+        if (d->te->toPlainText().isEmpty()) {
+            this->doButton();
+        }
+    });
     resize(400, 240);
 }
 


### PR DESCRIPTION
When I need to leave immediately I can set the Away status but then I'll be asked to set the status message. But might already leave so my status remains unchanged. Similarly if I'm a new user I wanted to set the "Free for chat" but then the status dialog is shown and I didn't know what it is.

So I would like to propose to disable the status message dialog for all statuses except of Not Available which is expected to be used a long term away message (illness, day off, sleep etc).

Additionally I added a 5 seconds timer that will simply close the status message dialog if user didn't typed anything.
