### PR TITLE
Plugins options: add description column

### DIFF
--- a/src/options/opt_plugins.cpp
+++ b/src/options/opt_plugins.cpp
@@ -121,9 +121,12 @@ void OptionsTabPlugins::listPlugins()
         Qt::CheckState   state               = enabled ? Qt::Checked : Qt::Unchecked;
         QTreeWidgetItem *item                = new QTreeWidgetItem(d->tw_Plugins, QTreeWidgetItem::Type);
         auto             truncatedPluginName = QString(pluginName).replace(" Plugin", "");
+        auto truncatedDescription = QString(description);
+        truncatedDescription.truncate(80);
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         item->setData(C_NAME, Qt::UserRole, shortName);
         item->setText(C_NAME, truncatedPluginName);
+        item->setText(C_DESCRIPTION, truncatedDescription);
         item->setText(C_VERSION, pm->version(shortName));
         item->setTextAlignment(C_VERSION, Qt::AlignHCenter);
         item->setToolTip(C_NAME, toolTip);
@@ -150,6 +153,7 @@ void OptionsTabPlugins::listPlugins()
     if (d->tw_Plugins->topLevelItemCount() > 0) {
         d->tw_Plugins->sortItems(C_NAME, Qt::AscendingOrder);
         d->tw_Plugins->header()->setSectionResizeMode(C_NAME, QHeaderView::Stretch);
+        d->tw_Plugins->resizeColumnToContents(C_DESCRIPTION);
         d->tw_Plugins->resizeColumnToContents(C_VERSION);
         d->tw_Plugins->resizeColumnToContents(C_ABOUT);
         d->tw_Plugins->resizeColumnToContents(C_SETTS);

--- a/src/options/opt_plugins.h
+++ b/src/options/opt_plugins.h
@@ -13,7 +13,7 @@ class QWidget;
 
 class OptionsTabPlugins : public OptionsTab {
     Q_OBJECT
-    enum ColumnName { C_NAME = 0, C_VERSION = 1, C_ABOUT = 2, C_SETTS = 3 };
+    enum ColumnName { C_NAME = 0, C_DESCRIPTION = 1, C_VERSION = 2, C_ABOUT = 3, C_SETTS = 4 };
 
 public:
     OptionsTabPlugins(QObject *parent);

--- a/src/options/opt_plugins.ui
+++ b/src/options/opt_plugins.ui
@@ -70,6 +70,14 @@
        </column>
        <column>
         <property name="text">
+         <string>Description</string>
+        </property>
+        <property name="textAlignment">
+         <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+        </property>
+       </column>
+       <column>
+        <property name="text">
          <string>Version</string>
         </property>
         <property name="textAlignment">


### PR DESCRIPTION
1. The plugin description is added as a column so a user don't need to click on the Info icon
2. The info icon is always enabled even the plugin is not enabled.
3. Don't shadow the plugin icon - it's enough of the checkbox.

<img width="1956" height="1252" alt="PSI plugins options" src="https://github.com/user-attachments/assets/362934df-369d-48c5-9a26-c665acd11264" />

The plugin description will be truncated to 80 characters because then it's called `resizeColumnToContents`. Maybe it's possible to just resize the column somehow without truncating a string.

The problem is that even when truncated the description is too big and takes all the place:
<img width="1020" height="794" alt="image" src="https://github.com/user-attachments/assets/1536f74c-0a3c-43cb-971c-38326a37a7ac" />
