### PR TITLE
Enable by default E2E encryption plugins and Attention plugin

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -801,5 +801,12 @@ QLineEdit#le_status_text {
         </keychain>
     </options>
     <accounts comment="Account definitions and options"/>
-    <plugins comment="Plugin options"/>
+    <plugins comment="Plugin options">
+        <auto-load>
+            <attention type="bool">true</attention>
+            <otr type="bool">true</otr>
+            <omemo type="bool">true</omemo>
+            <openpgp type="bool">true</openpgp>
+        </auto-load>
+    </plugins>
 </psi>


### PR DESCRIPTION
The encryption should be easily available even for inexperienced users.
The Attention functionality is standard in other clients.

Existing clients won't be affected, only new profiles.

Closes: #855