### PR TITLE
Make windows bigger

### DIFF
--- a/options/default.xml
+++ b/options/default.xml
@@ -266,8 +266,8 @@ QLineEdit#le_status_text {
                 <saved-window-geometry type="QRect" >
                     <x>64</x>
                     <y>64</y>
-                    <width>220</width>
-                    <height>360</height>
+                    <width>500</width>
+                    <height>800</height>
                 </saved-window-geometry>
                 <saved-window-geometry-frame type="QRect" >
                     <x>0</x>

--- a/src/about.ui
+++ b/src/about.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>625</width>
-    <height>320</height>
+    <width>640</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/accountadd.ui
+++ b/src/accountadd.ui
@@ -8,8 +8,8 @@
       <rect>
         <x>0</x>
         <y>0</y>
-        <width>465</width>
-        <height>252</height>
+        <width>600</width>
+        <height>400</height>
       </rect>
     </property>
     <property name="windowTitle" >

--- a/src/accountmanage.ui
+++ b/src/accountmanage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
-    <height>280</height>
+    <width>640</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/accountmodify.ui
+++ b/src/accountmodify.ui
@@ -112,7 +112,14 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLineEdit" name="le_jid"/>
+             <widget class="QLineEdit" name="le_jid">
+              <property name="inputMethodHints">
+               <set>Qt::ImhEmailCharactersOnly|Qt::ImhNoAutoUppercase|Qt::ImhPreferLatin|Qt::ImhPreferLowercase</set>
+              </property>
+              <property name="placeholderText">
+               <string extracomment="Like email">yourname@server.test</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -142,6 +149,9 @@
             </item>
             <item>
              <widget class="QLineEdit" name="le_pass">
+              <property name="inputMethodHints">
+               <set>Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhPreferLatin|Qt::ImhSensitiveData</set>
+              </property>
               <property name="echoMode">
                <enum>QLineEdit::Password</enum>
               </property>

--- a/src/accountmodify.ui
+++ b/src/accountmodify.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>765</width>
-    <height>655</height>
+    <width>1024</width>
+    <height>800</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/accountmodify.ui
+++ b/src/accountmodify.ui
@@ -711,13 +711,13 @@
           <widget class="QLineEdit" name="le_port">
            <property name="minimumSize">
             <size>
-             <width>56</width>
+             <width>80</width>
              <height>0</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>56</width>
+             <width>120</width>
              <height>32767</height>
             </size>
            </property>

--- a/src/accountreg.ui
+++ b/src/accountreg.ui
@@ -1,18 +1,19 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>AccountReg</class>
- <widget class="QDialog" name="AccountReg" >
-  <property name="geometry" >
+ <widget class="QDialog" name="AccountReg">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>384</width>
-    <height>339</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Register Account</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>9</number>
    </property>
@@ -20,12 +21,12 @@
     <number>6</number>
    </property>
    <item>
-    <widget class="QStackedWidget" name="sw_register" >
-     <property name="currentIndex" >
+    <widget class="QStackedWidget" name="sw_register">
+     <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="page_server" >
-      <layout class="QVBoxLayout" >
+     <widget class="QWidget" name="page_server">
+      <layout class="QVBoxLayout">
        <property name="margin" >
         <number>9</number>
        </property>
@@ -33,30 +34,30 @@
         <number>6</number>
        </property>
        <item>
-        <widget class="QGroupBox" name="gb_server" >
-         <property name="title" >
+        <widget class="QGroupBox" name="gb_server">
+         <property name="title">
           <string>Server</string>
          </property>
-         <layout class="QGridLayout" >
+         <layout class="QGridLayout">
           <property name="margin" >
            <number>9</number>
           </property>
-          <property name="spacing" >
+          <property name="spacing">
            <number>6</number>
           </property>
           <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="lb_jid" >
-            <property name="text" >
+           <widget class="QLabel" name="lb_jid">
+            <property name="text">
              <string>Please enter the name of the server you wish to register with:</string>
             </property>
-            <property name="wordWrap" >
+            <property name="wordWrap">
              <bool>true</bool>
             </property>
            </widget>
           </item>
           <item row="1" column="0" colspan="2">
            <widget class="UpdatingComboBox" name="le_server" >
-            <property name="minimumSize" >
+            <property name="minimumSize">
              <size>
               <width>200</width>
               <height>0</height>
@@ -68,11 +69,11 @@
            </widget>
           </item>
           <item row="2" column="0" colspan="2">
-           <widget class="QLabel" name="lb_example" >
-            <property name="enabled" >
+           <widget class="QLabel" name="lb_example">
+            <property name="enabled">
              <bool>false</bool>
             </property>
-            <property name="text" >
+            <property name="text">
              <string>Example: capulet.com</string>
             </property>
            </widget>
@@ -81,11 +82,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="gb_connection" >
-         <property name="title" >
+        <widget class="QGroupBox" name="gb_connection">
+         <property name="title">
           <string>Connection settings</string>
          </property>
-         <layout class="QVBoxLayout" >
+         <layout class="QVBoxLayout">
           <property name="margin" >
            <number>9</number>
           </property>
@@ -93,46 +94,46 @@
            <number>6</number>
           </property>
           <item>
-           <widget class="QCheckBox" name="ck_host" >
-            <property name="text" >
+           <widget class="QCheckBox" name="ck_host">
+            <property name="text">
              <string>Manually Specify Server Host/Port:</string>
             </property>
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" >
+           <layout class="QHBoxLayout">
             <property name="margin" >
              <number>0</number>
             </property>
-            <property name="spacing" >
+            <property name="spacing">
              <number>6</number>
             </property>
             <item>
-             <widget class="QLabel" name="lb_host" >
-              <property name="text" >
+             <widget class="QLabel" name="lb_host">
+              <property name="text">
                <string>Host:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="le_host" />
+             <widget class="QLineEdit" name="le_host"/>
             </item>
             <item>
-             <widget class="QLabel" name="lb_port" >
-              <property name="text" >
+             <widget class="QLabel" name="lb_port">
+              <property name="text">
                <string>Port:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLineEdit" name="le_port" >
-              <property name="minimumSize" >
+             <widget class="QLineEdit" name="le_port">
+              <property name="minimumSize">
                <size>
                 <width>56</width>
                 <height>0</height>
                </size>
               </property>
-              <property name="maximumSize" >
+              <property name="maximumSize">
                <size>
                 <width>56</width>
                 <height>32767</height>
@@ -143,7 +144,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" >
+           <layout class="QHBoxLayout">
             <property name="margin" >
              <number>0</number>
             </property>
@@ -151,21 +152,21 @@
              <number>6</number>
             </property>
             <item>
-             <widget class="QLabel" name="lb_ssl" >
-              <property name="text" >
+             <widget class="QLabel" name="lb_ssl">
+              <property name="text">
                <string>Encrypt connection:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QComboBox" name="cb_ssl" />
+             <widget class="QComboBox" name="cb_ssl"/>
             </item>
             <item>
              <spacer>
-              <property name="orientation" >
+              <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
-              <property name="sizeType" >
+              <property name="sizeType">
                <enum>QSizePolicy::Expanding</enum>
               </property>
               <property name="sizeHint" >
@@ -179,23 +180,23 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" >
+           <layout class="QHBoxLayout">
             <property name="margin" >
              <number>0</number>
             </property>
-            <property name="spacing" >
+            <property name="spacing">
              <number>6</number>
             </property>
             <item>
-             <widget class="QLabel" name="lb_proxy" >
-              <property name="text" >
+             <widget class="QLabel" name="lb_proxy">
+              <property name="text">
                <string>Proxy:</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QLabel" name="lb_proxychooser" >
-              <property name="text" >
+             <widget class="QLabel" name="lb_proxychooser">
+              <property name="text">
                <string>proxychooser</string>
               </property>
              </widget>
@@ -207,10 +208,10 @@
        </item>
        <item>
         <spacer>
-         <property name="orientation" >
+         <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <property name="sizeType" >
+         <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
          </property>
          <property name="sizeHint" >
@@ -223,24 +224,24 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_fields" />
+     <widget class="QWidget" name="page_fields"/>
     </widget>
    </item>
    <item>
-    <widget class="Line" name="line2" >
-     <property name="frameShape" >
+    <widget class="Line" name="line2">
+     <property name="frameShape">
       <enum>QFrame::HLine</enum>
      </property>
-     <property name="frameShadow" >
+     <property name="frameShadow">
       <enum>QFrame::Sunken</enum>
      </property>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -252,7 +253,7 @@
      </item>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" >
@@ -264,18 +265,18 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_cancel" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_cancel">
+       <property name="text">
         <string>&amp;Cancel</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_next" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_next">
+       <property name="text">
         <string>&amp;Next</string>
        </property>
-       <property name="default" >
+       <property name="default">
         <bool>true</bool>
        </property>
       </widget>
@@ -284,7 +285,7 @@
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>le_server</tabstop>
   <tabstop>ck_host</tabstop>

--- a/src/accountremove.ui
+++ b/src/accountremove.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>459</width>
-    <height>186</height>
+    <width>880</width>
+    <height>280</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/activity.ui
+++ b/src/activity.ui
@@ -1,55 +1,56 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>Activity</class>
- <widget class="QDialog" name="Activity" >
-  <property name="geometry" >
+ <widget class="QDialog" name="Activity">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>313</width>
-    <height>162</height>
+    <width>640</width>
+    <height>260</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>User Activity</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <item>
-    <layout class="QGridLayout" >
-     <item row="0" column="0" >
-      <widget class="QLabel" name="label" >
-       <property name="text" >
+    <layout class="QGridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
         <string>General:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1" >
-      <widget class="QComboBox" name="cb_general_type" />
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cb_general_type"/>
      </item>
-     <item row="1" column="0" >
-      <widget class="QLabel" name="label_3" >
-       <property name="text" >
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
         <string>Specific:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" >
-      <widget class="QComboBox" name="cb_specific_type" />
+     <item row="1" column="1">
+      <widget class="QComboBox" name="cb_specific_type"/>
      </item>
-     <item row="2" column="0" >
-      <widget class="QLabel" name="label_2" >
-       <property name="text" >
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
         <string>Description:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" >
-      <widget class="QLineEdit" name="le_description" />
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="le_description"/>
      </item>
     </layout>
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" >
@@ -61,25 +62,25 @@
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
-     <property name="spacing" >
+    <layout class="QHBoxLayout">
+     <property name="spacing">
       <number>6</number>
      </property>
-     <property name="leftMargin" >
+     <property name="leftMargin">
       <number>0</number>
      </property>
-     <property name="topMargin" >
+     <property name="topMargin">
       <number>0</number>
      </property>
-     <property name="rightMargin" >
+     <property name="rightMargin">
       <number>0</number>
      </property>
-     <property name="bottomMargin" >
+     <property name="bottomMargin">
       <number>0</number>
      </property>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" >
@@ -91,15 +92,15 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_ok" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_ok">
+       <property name="text">
         <string>OK</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_cancel" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_cancel">
+       <property name="text">
         <string>Cancel</string>
        </property>
       </widget>

--- a/src/addurl.ui
+++ b/src/addurl.ui
@@ -1,121 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" stdsetdef="1" >
   <author></author>
   <comment></comment>
   <exportmacro></exportmacro>
-  <class>AddUrl</class>
-  <widget class="QDialog" name="AddUrl" >
-    <property name="geometry" >
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>337</width>
-        <height>123</height>
-      </rect>
-    </property>
-    <property name="windowTitle" >
-      <string>Add URL</string>
-    </property>
-    <layout class="QVBoxLayout" >
+ <class>AddUrl</class>
+ <widget class="QDialog" name="AddUrl">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add URL</string>
+  </property>
+  <layout class="QVBoxLayout">
       <property name="margin" >
-        <number>11</number>
-      </property>
+    <number>11</number>
+   </property>
       <property name="spacing" >
         <number>6</number>
-      </property>
-      <item>
-        <layout class="QGridLayout" >
+   </property>
+   <item>
+    <layout class="QGridLayout">
           <property name="margin" >
-            <number>0</number>
-          </property>
-          <property name="spacing" >
-            <number>6</number>
-          </property>
-          <item row="1" column="1" >
-            <widget class="QLineEdit" name="le_desc" />
-          </item>
-          <item row="0" column="0" >
-            <widget class="QLabel" name="TextLabel1" >
-              <property name="text" >
-                <string>URL:</string>
-              </property>
-            </widget>
-          </item>
-          <item row="1" column="0" >
-            <widget class="QLabel" name="TextLabel2" >
-              <property name="text" >
-                <string>Description:</string>
-              </property>
-            </widget>
-          </item>
-          <item row="0" column="1" >
-            <widget class="QLineEdit" name="le_url" />
-          </item>
-        </layout>
-      </item>
-      <item>
-        <spacer name="Spacer2" >
+      <number>0</number>
+     </property>
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="le_desc"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="TextLabel1">
+       <property name="text">
+        <string>URL:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="TextLabel2">
+       <property name="text">
+        <string>Description:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="le_url"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="Spacer2">
           <property name="sizeHint" >
-            <size>
-              <width>16</width>
-              <height>16</height>
-            </size>
-          </property>
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
           <property name="sizeType" >
             <enum>Expanding</enum>
           </property>
           <property name="orientation" >
             <enum>Vertical</enum>
           </property>
-        </spacer>
-      </item>
-      <item>
-        <layout class="QHBoxLayout" >
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout">
           <property name="margin" >
-            <number>0</number>
-          </property>
-          <item>
-            <spacer name="Spacer1" >
+      <number>0</number>
+     </property>
+     <item>
+      <spacer name="Spacer1">
               <property name="sizeHint" >
-                <size>
-                  <width>203</width>
-                  <height>16</height>
-                </size>
-              </property>
+        <size>
+         <width>203</width>
+         <height>16</height>
+        </size>
+       </property>
               <property name="sizeType" >
                 <enum>Expanding</enum>
               </property>
               <property name="orientation" >
                 <enum>Horizontal</enum>
               </property>
-            </spacer>
-          </item>
-          <item>
+      </spacer>
+     </item>
+     <item>
             <widget class="IconButton" name="pb_close" >
               <property name="text" >
-                <string>&amp;Close</string>
-              </property>
-            </widget>
-          </item>
-          <item>
+        <string>&amp;Close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
             <widget class="IconButton" name="pb_ok" >
               <property name="text" >
-                <string>&amp;OK</string>
-              </property>
+        <string>&amp;OK</string>
+       </property>
               <property name="shortcut" >
-                <string>Alt+O</string>
-              </property>
+        <string>Alt+O</string>
+       </property>
               <property name="default" >
-                <bool>true</bool>
-              </property>
-            </widget>
-          </item>
-        </layout>
-      </item>
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
-  </widget>
-  <layoutdefault spacing="6" margin="11" />
-  <tabstops>
-    <tabstop>le_url</tabstop>
-    <tabstop>le_desc</tabstop>
-  </tabstops>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>le_url</tabstop>
+  <tabstop>le_desc</tabstop>
+ </tabstops>
 </ui>

--- a/src/adduser.ui
+++ b/src/adduser.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>566</width>
-    <height>375</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -286,16 +286,16 @@ p, li { white-space: pre-wrap; }
         <spacer name="Spacer2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
-         </property>
+       </property>
          <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
-         </property>
+       </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>140</width>
            <height>20</height>
           </size>
-         </property>
+       </property>
         </spacer>
        </item>
        <item>

--- a/src/ahcformdlg.ui
+++ b/src/ahcformdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>327</width>
-    <height>241</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/bookmarkmanage.ui
+++ b/src/bookmarkmanage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>289</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/changepw.ui
+++ b/src/changepw.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>331</width>
-    <height>179</height>
+    <width>640</width>
+    <height>260</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/chatdlg.ui
+++ b/src/chatdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>463</width>
-    <height>344</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/disco.ui
+++ b/src/disco.ui
@@ -1,21 +1,22 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <author></author>
  <comment></comment>
  <exportmacro></exportmacro>
  <class>Disco</class>
- <widget class="QWidget" name="Disco" >
-  <property name="geometry" >
+ <widget class="QWidget" name="Disco">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>523</width>
-    <height>404</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Service Discovery</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>0</number>
    </property>
@@ -23,14 +24,14 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="toolBarPlaceholder" >
-     <property name="text" >
-      <string comment="Don't translate this string" >ToolBar will be placed here</string>
+    <widget class="QLabel" name="toolBarPlaceholder">
+     <property name="text">
+      <string comment="Don't translate this string">ToolBar will be placed here</string>
      </property>
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" >
+    <layout class="QVBoxLayout">
      <property name="margin" >
       <number>11</number>
      </property>
@@ -38,7 +39,7 @@
       <number>6</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" >
+      <layout class="QHBoxLayout">
        <property name="margin" >
         <number>0</number>
        </property>
@@ -46,18 +47,18 @@
         <number>6</number>
        </property>
        <item>
-        <widget class="QLabel" name="textLabel1" >
-         <property name="text" >
+        <widget class="QLabel" name="textLabel1">
+         <property name="text">
           <string>&amp;Address:</string>
          </property>
-         <property name="buddy" >
+         <property name="buddy">
           <cstring>cb_address</cstring>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="cb_address" >
-         <property name="sizePolicy" >
+        <widget class="QComboBox" name="cb_address">
+         <property name="sizePolicy">
           <sizepolicy>
            <hsizetype>7</hsizetype>
            <vsizetype>0</vsizetype>
@@ -65,24 +66,24 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="editable" >
+         <property name="editable">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="lb_node" >
-         <property name="text" >
+        <widget class="QLabel" name="lb_node">
+         <property name="text">
           <string>&amp;Node:</string>
          </property>
-         <property name="buddy" >
+         <property name="buddy">
           <cstring>cb_node</cstring>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="cb_node" >
-         <property name="sizePolicy" >
+        <widget class="QComboBox" name="cb_node">
+         <property name="sizePolicy">
           <sizepolicy>
            <hsizetype>7</hsizetype>
            <vsizetype>0</vsizetype>
@@ -90,26 +91,26 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize" >
+         <property name="minimumSize">
           <size>
            <width>0</width>
            <height>0</height>
           </size>
          </property>
-         <property name="maximumSize" >
+         <property name="maximumSize">
           <size>
            <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
-         <property name="editable" >
+         <property name="editable">
           <bool>true</bool>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pb_browse" >
-         <property name="text" >
+        <widget class="QPushButton" name="pb_browse">
+         <property name="text">
           <string>&amp;Browse</string>
          </property>
         </widget>
@@ -120,55 +121,55 @@
       <widget class="QTreeWidget" name="lv_disco" />
      </item>
      <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Filter by JID:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="le_filter"/>
+       </item>
+      </layout>
+     </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QCheckBox" name="ck_autoItems">
        <property name="text">
-        <string>Filter by JID:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="le_filter"/>
-     </item>
-    </layout>
-   </item>
-     <item>
-      <widget class="QCheckBox" name="ck_autoItems" >
-       <property name="text" >
         <string>Auto-browse into objects</string>
        </property>
-       <property name="checked" >
+       <property name="checked">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="ck_autoInfo" >
-       <property name="text" >
+      <widget class="QCheckBox" name="ck_autoInfo">
+       <property name="text">
         <string>Automatically get item information</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="Line" name="line3" >
-       <property name="frameShape" >
+      <widget class="Line" name="line3">
+       <property name="frameShape">
         <enum>QFrame::HLine</enum>
        </property>
-       <property name="frameShadow" >
+       <property name="frameShadow">
         <enum>QFrame::Sunken</enum>
        </property>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" >
+      <layout class="QHBoxLayout">
        <property name="margin" >
         <number>0</number>
        </property>
-       <property name="spacing" >
+       <property name="spacing">
         <number>6</number>
        </property>
        <item>
@@ -176,10 +177,10 @@
        </item>
        <item>
         <spacer>
-         <property name="orientation" >
+         <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
-         <property name="sizeType" >
+         <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
          </property>
          <property name="sizeHint" >
@@ -203,7 +204,7 @@
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>BusyWidget</class>

--- a/src/filesharedlg.ui
+++ b/src/filesharedlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>593</width>
-    <height>579</height>
+    <width>640</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/filetrans.ui
+++ b/src/filetrans.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>334</width>
-    <height>289</height>
+    <width>640</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/groupchatdlg.ui
+++ b/src/groupchatdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>633</width>
-    <height>428</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/groupchattopicaddlang.ui
+++ b/src/groupchattopicaddlang.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>301</width>
-    <height>154</height>
+    <width>400</width>
+    <height>240</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/groupchattopicdlg.ui
+++ b/src/groupchattopicdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
-    <height>450</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/history.ui
+++ b/src/history.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>672</width>
+    <width>800</width>
     <height>680</height>
    </rect>
   </property>
@@ -151,7 +151,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QLabel" name="label">
            <property name="text">
@@ -168,7 +168,7 @@
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
+                 <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
               </widget>

--- a/src/info.ui
+++ b/src/info.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>450</width>
-    <height>323</height>
+    <width>800</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="sizeGripEnabled" stdset="0">

--- a/src/infodlg.ui
+++ b/src/infodlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>308</width>
-    <height>106</height>
+    <width>400</width>
+    <height>200</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/mood.ui
+++ b/src/mood.ui
@@ -1,21 +1,22 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <author></author>
  <comment></comment>
  <exportmacro></exportmacro>
  <class>Mood</class>
- <widget class="QDialog" name="Mood" >
-  <property name="geometry" >
+ <widget class="QDialog" name="Mood">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>241</width>
-    <height>120</height>
+    <width>400</width>
+    <height>180</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Set Mood</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>9</number>
    </property>
@@ -23,29 +24,29 @@
     <number>6</number>
    </property>
    <item>
-    <layout class="QGridLayout" >
+    <layout class="QGridLayout">
      <property name="margin" >
       <number>0</number>
      </property>
-     <property name="spacing" >
+     <property name="spacing">
       <number>6</number>
      </property>
-     <item row="0" column="1" >
-      <widget class="QComboBox" name="cb_type" />
+     <item row="0" column="1">
+      <widget class="QComboBox" name="cb_type"/>
      </item>
-     <item row="0" column="0" >
-      <widget class="QLabel" name="label" >
-       <property name="text" >
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
         <string>Type:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" >
-      <widget class="QLineEdit" name="le_text" />
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="le_text"/>
      </item>
-     <item row="1" column="0" >
-      <widget class="QLabel" name="label_2" >
-       <property name="text" >
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
         <string>Text:</string>
        </property>
       </widget>
@@ -54,7 +55,7 @@
    </item>
    <item>
     <spacer>
-     <property name="orientation" >
+     <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" >
@@ -66,7 +67,7 @@
     </spacer>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -75,7 +76,7 @@
      </property>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" >
@@ -87,15 +88,15 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_ok" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_ok">
+       <property name="text">
         <string>OK</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_cancel" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_cancel">
+       <property name="text">
         <string>Cancel</string>
        </property>
       </widget>

--- a/src/mucconfig.ui
+++ b/src/mucconfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>483</width>
-    <height>375</height>
+    <width>640</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/mucinfo.ui
+++ b/src/mucinfo.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>491</width>
-    <height>275</height>
+    <width>640</width>
+    <height>340</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/mucjoin.ui
+++ b/src/mucjoin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>421</height>
+    <width>640</width>
+    <height>800</height>
    </rect>
   </property>
   <property name="minimumSize">

--- a/src/mucreasonseditor.ui
+++ b/src/mucreasonseditor.ui
@@ -1,18 +1,19 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>MUCReasonsEditor</class>
- <widget class="QDialog" name="MUCReasonsEditor" >
-  <property name="geometry" >
+ <widget class="QDialog" name="MUCReasonsEditor">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Reason editor</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>9</number>
    </property>
@@ -20,11 +21,11 @@
     <number>6</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Reasons</string>
      </property>
-     <layout class="QVBoxLayout" >
+     <layout class="QVBoxLayout">
       <property name="margin" >
        <number>9</number>
       </property>
@@ -32,17 +33,17 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QLineEdit" name="txtReason" >
-        <property name="text" >
+       <widget class="QLineEdit" name="txtReason">
+        <property name="text">
          <string/>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QListWidget" name="lstReasons" />
+       <widget class="QListWidget" name="lstReasons"/>
       </item>
       <item>
-       <layout class="QHBoxLayout" >
+       <layout class="QHBoxLayout">
         <property name="margin" >
          <number>0</number>
         </property>
@@ -50,15 +51,15 @@
          <number>6</number>
         </property>
         <item>
-         <widget class="QPushButton" name="btnAdd" >
-          <property name="text" >
+         <widget class="QPushButton" name="btnAdd">
+          <property name="text">
            <string>Add</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btnRemove" >
-          <property name="text" >
+         <widget class="QPushButton" name="btnRemove">
+          <property name="text">
            <string>Remove</string>
           </property>
          </widget>
@@ -69,7 +70,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -85,7 +86,7 @@
      </item>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" >
@@ -97,21 +98,21 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="btnOk" >
-       <property name="text" >
+      <widget class="QPushButton" name="btnOk">
+       <property name="text">
         <string>Ok</string>
        </property>
-       <property name="autoDefault" >
+       <property name="autoDefault">
         <bool>false</bool>
        </property>
-       <property name="default" >
+       <property name="default">
         <bool>true</bool>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnCancel" >
-       <property name="text" >
+      <widget class="QPushButton" name="btnCancel">
+       <property name="text">
         <string>Cancel</string>
        </property>
       </widget>
@@ -128,11 +129,11 @@
    <receiver>MUCReasonsEditor</receiver>
    <slot>accept()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>265</x>
      <y>271</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>-2</x>
      <y>287</y>
     </hint>
@@ -144,11 +145,11 @@
    <receiver>MUCReasonsEditor</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>341</x>
      <y>283</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>81</x>
      <y>272</y>
     </hint>
@@ -160,11 +161,11 @@
    <receiver>MUCReasonsEditor</receiver>
    <slot>save()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>35</x>
      <y>282</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>199</x>
      <y>149</y>
     </hint>

--- a/src/multifiletransferdlg.ui
+++ b/src/multifiletransferdlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>640</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="acceptDrops">

--- a/src/optioneditor.ui
+++ b/src/optioneditor.ui
@@ -1,21 +1,22 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>OptionEditor</class>
- <widget class="QDialog" name="OptionEditor" >
-  <property name="geometry" >
+ <widget class="QDialog" name="OptionEditor">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>324</width>
-    <height>146</height>
+    <width>640</width>
+    <height>200</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>9</number>
    </property>
-   <property name="spacing" >
-    <number>6</number>
-   </property>
+     <property name="spacing">
+      <number>6</number>
+     </property>
    <item>
     <layout class="QHBoxLayout" >
      <property name="margin" >
@@ -25,22 +26,22 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QLabel" name="label" >
-       <property name="text" >
+      <widget class="QLabel" name="label">
+       <property name="text">
         <string>Option:</string>
        </property>
-       <property name="buddy" >
+       <property name="buddy">
         <cstring>le_option</cstring>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="le_option" />
+      <widget class="QLineEdit" name="le_option"/>
      </item>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -48,31 +49,31 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QLabel" name="label_2" >
-       <property name="text" >
+      <widget class="QLabel" name="label_2">
+       <property name="text">
         <string>Type:</string>
        </property>
-       <property name="buddy" >
+       <property name="buddy">
         <cstring>le_value</cstring>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="cb_typ" />
+      <widget class="QComboBox" name="cb_typ"/>
      </item>
      <item>
-      <widget class="QLabel" name="label_3" >
-       <property name="text" >
+      <widget class="QLabel" name="label_3">
+       <property name="text">
         <string>Value: </string>
        </property>
-       <property name="buddy" >
+       <property name="buddy">
         <cstring>le_value</cstring>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="le_value" >
-       <property name="sizePolicy" >
+      <widget class="QLineEdit" name="le_value">
+       <property name="sizePolicy">
         <sizepolicy>
          <hsizetype>3</hsizetype>
          <vsizetype>0</vsizetype>
@@ -80,7 +81,7 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="minimumSize" >
+       <property name="minimumSize">
         <size>
          <width>150</width>
          <height>0</height>
@@ -91,27 +92,27 @@
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="lb_comment" >
-     <property name="text" >
+    <widget class="QLabel" name="lb_comment">
+     <property name="text">
       <string/>
      </property>
-     <property name="textFormat" >
+     <property name="textFormat">
       <enum>Qt::PlainText</enum>
      </property>
-     <property name="wordWrap" >
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
-     <property name="textInteractionFlags" >
+     <property name="textInteractionFlags">
       <enum>Qt::TextSelectableByMouse</enum>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="orientation" >
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <property name="standardButtons" >
+     <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::NoButton|QDialogButtonBox::Ok</set>
      </property>
     </widget>
@@ -126,11 +127,11 @@
    <receiver>OptionEditor</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>260</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
     </hint>

--- a/src/pgpkey.ui
+++ b/src/pgpkey.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>522</width>
-    <height>318</height>
+    <width>640</width>
+    <height>400</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">

--- a/src/profilemanage.ui
+++ b/src/profilemanage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>330</width>
-    <height>254</height>
+    <width>400</width>
+    <height>300</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/profilenew.ui
+++ b/src/profilenew.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>459</width>
+    <width>640</width>
     <height>311</height>
    </rect>
   </property>

--- a/src/profileopen.ui
+++ b/src/profileopen.ui
@@ -1,209 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" stdsetdef="1" >
   <author></author>
   <comment></comment>
   <exportmacro></exportmacro>
-  <class>ProfileOpen</class>
-  <widget class="QDialog" name="ProfileOpen" >
-    <property name="geometry" >
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>305</width>
-        <height>197</height>
-      </rect>
-    </property>
-    <property name="windowTitle" >
-      <string>Open Profile</string>
-    </property>
-    <layout class="QVBoxLayout" >
+ <class>ProfileOpen</class>
+ <widget class="QDialog" name="ProfileOpen">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>640</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Open Profile</string>
+  </property>
+  <layout class="QVBoxLayout">
       <property name="margin" >
-        <number>0</number>
-      </property>
+    <number>0</number>
+   </property>
       <property name="spacing" >
-        <number>0</number>
-      </property>
-      <item>
-        <layout class="QHBoxLayout" >
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout">
           <property name="margin" >
-            <number>0</number>
-          </property>
+      <number>0</number>
+     </property>
           <property name="spacing" >
-            <number>0</number>
-          </property>
-          <item>
-            <widget class="QLabel" name="lb_left" >
-              <property name="text" >
-                <string>left</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <widget class="QLabel" name="lb_logo" >
-              <property name="text" >
-                <string>Image goes here</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <widget class="QLabel" name="lb_right" >
-              <property name="text" >
-                <string>right</string>
-              </property>
-            </widget>
-          </item>
-        </layout>
-      </item>
-      <item>
-        <layout class="QVBoxLayout" >
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="lb_left">
+       <property name="text">
+        <string>left</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lb_logo">
+       <property name="text">
+        <string>Image goes here</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lb_right">
+       <property name="text">
+        <string>right</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout">
           <property name="margin" >
-            <number>11</number>
-          </property>
-          <item>
-            <widget class="QGroupBox" name="gb_open" >
-              <property name="title" >
-                <string>Open Profile</string>
-              </property>
-              <layout class="QVBoxLayout" >
+      <number>11</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="gb_open">
+       <property name="title">
+        <string>Open Profile</string>
+       </property>
+       <layout class="QVBoxLayout">
                 <property name="margin" >
                   <number>11</number>
                 </property>
-                <property name="spacing" >
-                  <number>6</number>
-                </property>
-                <item>
-                  <layout class="QHBoxLayout" >
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout">
                     <property name="margin" >
-                      <number>0</number>
-                    </property>
+           <number>0</number>
+          </property>
                     <property name="spacing" >
                       <number>6</number>
-                    </property>
-                    <item>
-                      <widget class="QLabel" name="TextLabel4" >
-                        <property name="text" >
-                          <string>Profile:</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item>
-                      <widget class="QComboBox" name="cb_profile" >
-                        <property name="sizePolicy" >
+          </property>
+          <item>
+           <widget class="QLabel" name="TextLabel4">
+            <property name="text">
+             <string>Profile:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="cb_profile">
+            <property name="sizePolicy">
                           <sizepolicy>
                             <hsizetype>7</hsizetype>
                             <vsizetype>0</vsizetype>
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </item>
-                <item>
-                  <widget class="QCheckBox" name="ck_auto" >
-                    <property name="text" >
-                      <string>&amp;Automatically open on startup</string>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </widget>
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
           </item>
-          <item>
-            <layout class="QHBoxLayout" >
+         </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="ck_auto">
+          <property name="text">
+           <string>&amp;Automatically open on startup</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout">
               <property name="margin" >
-                <number>0</number>
-              </property>
+        <number>0</number>
+       </property>
               <property name="spacing" >
                 <number>6</number>
-              </property>
-              <item>
-                <widget class="QLabel" name="lb_lang" >
-                  <property name="text" >
-                    <string>Language:</string>
-                  </property>
-                </widget>
-              </item>
-              <item>
-                <widget class="QComboBox" name="cb_lang" >
-                  <property name="sizePolicy" >
+       </property>
+       <item>
+        <widget class="QLabel" name="lb_lang">
+         <property name="text">
+          <string>Language:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cb_lang">
+         <property name="sizePolicy">
                     <sizepolicy>
                       <hsizetype>7</hsizetype>
                       <vsizetype>0</vsizetype>
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                    </sizepolicy>
-                  </property>
-                </widget>
-              </item>
-            </layout>
-          </item>
-          <item>
-            <widget class="Line" name="Line1" >
-              <property name="frameShape" >
-                <enum>QFrame::HLine</enum>
-              </property>
-              <property name="frameShadow" >
-                <enum>QFrame::Sunken</enum>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <layout class="QHBoxLayout" >
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="Line" name="Line1">
+       <property name="frameShape">
+        <enum>QFrame::HLine</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Sunken</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout">
               <property name="margin" >
-                <number>0</number>
-              </property>
-              <item>
+        <number>0</number>
+       </property>
+       <item>
                 <widget class="IconButton" name="pb_close" >
                   <property name="text" >
-                    <string>&amp;Quit</string>
-                  </property>
-                  <property name="psiIconName" stdset="0" >
-                    <string>psi/quit</string>
-                  </property>
-                </widget>
-              </item>
-              <item>
-                <spacer name="Spacer1" >
+          <string>&amp;Quit</string>
+         </property>
+         <property name="psiIconName" stdset="0">
+          <string>psi/quit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="Spacer1">
                   <property name="sizeHint" >
-                    <size>
-                      <width>59</width>
-                      <height>20</height>
-                    </size>
-                  </property>
+          <size>
+           <width>59</width>
+           <height>20</height>
+          </size>
+         </property>
                   <property name="sizeType" >
                     <enum>Expanding</enum>
                   </property>
                   <property name="orientation" >
                     <enum>Horizontal</enum>
                   </property>
-                </spacer>
-              </item>
-              <item>
+        </spacer>
+       </item>
+       <item>
                 <widget class="IconButton" name="pb_profiles" >
                   <property name="text" >
-                    <string>&amp;Profiles...</string>
-                  </property>
-                  <property name="psiIconName" stdset="0" >
-                    <string>psi/profile</string>
-                  </property>
-                </widget>
-              </item>
-              <item>
+          <string>&amp;Profiles...</string>
+         </property>
+         <property name="psiIconName" stdset="0">
+          <string>psi/profile</string>
+         </property>
+        </widget>
+       </item>
+       <item>
                 <widget class="IconButton" name="pb_open" >
                   <property name="text" >
-                    <string>&amp;Open</string>
-                  </property>
-                  <property name="psiIconName" stdset="0" >
-                    <string>psi/logo_16</string>
-                  </property>
-                </widget>
-              </item>
-            </layout>
-          </item>
-        </layout>
-      </item>
+          <string>&amp;Open</string>
+         </property>
+         <property name="psiIconName" stdset="0">
+          <string>psi/logo_16</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
     </layout>
-  </widget>
-  <layoutdefault spacing="6" margin="11" />
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
 </ui>

--- a/src/proxy.ui
+++ b/src/proxy.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>622</width>
-    <height>346</height>
+    <width>800</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/rosteravatarframe.ui
+++ b/src/rosteravatarframe.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>260</width>
+    <width>400</width>
     <height>81</height>
    </rect>
   </property>

--- a/src/search.ui
+++ b/src/search.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>780</width>
+    <width>800</width>
     <height>480</height>
    </rect>
   </property>
@@ -89,8 +89,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>270</width>
-               <height>363</height>
+               <width>400</width>
+               <height>400</height>
               </rect>
              </property>
             </widget>

--- a/src/sendbuttontemplateseditor.ui
+++ b/src/sendbuttontemplateseditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>464</width>
-    <height>407</height>
+    <width>640</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/voicecall.ui
+++ b/src/voicecall.ui
@@ -1,76 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0" stdsetdef="1" >
   <author></author>
   <comment></comment>
   <exportmacro></exportmacro>
-  <class>VoiceCall</class>
-  <widget class="QDialog" name="VoiceCall" >
-    <property name="geometry" >
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>290</width>
-        <height>79</height>
-      </rect>
-    </property>
-    <property name="windowTitle" >
-      <string>Voice Call</string>
-    </property>
-    <layout class="QVBoxLayout" >
-      <item>
-        <widget class="QLabel" name="lb_status" >
-          <property name="text" >
-            <string/>
-          </property>
-          <property name="alignment" >
-            <set>Qt::AlignCenter</set>
-          </property>
-        </widget>
-      </item>
-      <item>
-        <layout class="QHBoxLayout" >
-          <property name="margin" >
-            <number>0</number>
-          </property>
-          <item>
-            <widget class="QPushButton" name="pb_accept" >
-              <property name="text" >
-                <string>Accept</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <widget class="QPushButton" name="pb_reject" >
-              <property name="text" >
-                <string>Reject</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <spacer name="spacer2" >
-              <property name="sizeHint" >
-                <size>
-                  <width>90</width>
-                  <height>32</height>
-                </size>
-              </property>
-              <property name="sizeType" >
-                <enum>Expanding</enum>
-              </property>
-              <property name="orientation" >
-                <enum>Horizontal</enum>
-              </property>
-            </spacer>
-          </item>
-          <item>
-            <widget class="QPushButton" name="pb_hangup" >
-              <property name="text" >
-                <string>Hang Up</string>
-              </property>
-            </widget>
-          </item>
-        </layout>
-      </item>
+ <class>VoiceCall</class>
+ <widget class="QDialog" name="VoiceCall">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Voice Call</string>
+  </property>
+  <layout class="QVBoxLayout">
+   <item>
+    <widget class="QLabel" name="lb_status">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1">
+      <widget class="QPushButton" name="pb_accept">
+       <property name="text">
+        <string>Accept</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="pb_reject">
+       <property name="text">
+        <string>Reject</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QPushButton" name="pb_hangup">
+       <property name="text">
+        <string>Hang Up</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-  </widget>
-  <layoutdefault spacing="6" margin="11" />
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
 </ui>

--- a/src/xmlconsole.ui
+++ b/src/xmlconsole.ui
@@ -1,18 +1,19 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>XMLConsole</class>
- <widget class="QWidget" name="XMLConsole" >
-  <property name="geometry" >
+ <widget class="QWidget" name="XMLConsole">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>447</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>XML Console</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <property name="margin" >
     <number>9</number>
    </property>
@@ -20,14 +21,14 @@
     <number>6</number>
    </property>
    <item>
-    <widget class="QTextEdit" name="te" />
+    <widget class="QTextEdit" name="te"/>
    </item>
    <item>
-    <widget class="QGroupBox" name="gb_filter" >
-     <property name="title" >
+    <widget class="QGroupBox" name="gb_filter">
+     <property name="title">
       <string>Filter</string>
      </property>
-     <layout class="QHBoxLayout" >
+     <layout class="QHBoxLayout">
       <property name="margin" >
        <number>9</number>
       </property>
@@ -35,48 +36,48 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QCheckBox" name="ck_message" >
-        <property name="text" >
+       <widget class="QCheckBox" name="ck_message">
+        <property name="text">
          <string>Message</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="ck_presence" >
-        <property name="text" >
+       <widget class="QCheckBox" name="ck_presence">
+        <property name="text">
          <string>Presence</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="ck_iq" >
-        <property name="text" >
+       <widget class="QCheckBox" name="ck_iq">
+        <property name="text">
          <string>IQ</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="ck_sm" >
-        <property name="text" >
+       <widget class="QCheckBox" name="ck_sm">
+        <property name="text">
          <string>SM</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-       <item>
+      <item>
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
         <property name="sizeHint" >
@@ -88,20 +89,20 @@
        </spacer>
       </item>
       <item>
-       <widget class="QLabel" name="label" >
-        <property name="text" >
+       <widget class="QLabel" name="label">
+        <property name="text">
          <string>JID:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="le_jid" />
+       <widget class="QLineEdit" name="le_jid"/>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <property name="margin" >
       <number>0</number>
      </property>
@@ -109,15 +110,15 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QCheckBox" name="ck_enable" >
-       <property name="text" >
+      <widget class="QCheckBox" name="ck_enable">
+       <property name="text">
         <string>Enable</string>
        </property>
       </widget>
      </item>
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
        <property name="sizeHint" >
@@ -129,29 +130,29 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_dumpRingbuf" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_dumpRingbuf">
+       <property name="text">
         <string>Dump Ringbuf</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_clear" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_clear">
+       <property name="text">
         <string>Clear</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_input" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_input">
+       <property name="text">
         <string>XML Input...</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="pb_close" >
-       <property name="text" >
+      <widget class="QPushButton" name="pb_close">
+       <property name="text">
         <string>Close</string>
        </property>
       </widget>


### PR DESCRIPTION
All windows and some controls are too small by default.
In the PR I tried to slightly increase their size but not too much. I tested on Ubuntu Mate that may have too big fonts so it may look worth on Win/ReactOS or MacOS. 
This is a minimal ad-hoc change, in fact we'll need to redesign more and add responsiveness.

I opened each .ui file in the QT Designer and it also made a lot of other migration changes, including its own resizing. I reverted all of them except of the sizes.

This will also need for more testing because I wasn't able to open some windows and can judge only by the QT Designer look.