### PR TITLE
Resolve entities

### DIFF
--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -200,10 +200,11 @@ QString TextUtil::resolveEntities(const QStringView &in)
         }
         // find a semicolon
         int n = in.indexOf(';', i+1);
-        if (n == -1)
-            break;
+        if (n == -1) {
+            out += in[i];
+            continue;
+        }
         auto type = in.mid(i+1, (n - (i+1)));
-
         if (type == QLatin1String { "amp" })
             out += '&';
         else if (type == QLatin1String { "lt" })
@@ -216,6 +217,10 @@ QString TextUtil::resolveEntities(const QStringView &in)
             out += '\'';
         else if (type == QLatin1String { "nbsp" })
             out += char(0xa0);
+        else {
+            out += in[i];
+            continue;
+        }
         i = n; // should be n+1, but we'll let the loop increment do it
     }
 

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -456,7 +456,7 @@ QString TextUtil::linkify(const QString &in)
 #else
             auto linkColor = ColorOpt::instance()->color("options.ui.look.colors.messages.link");
             // we have visited link as well but it's no applicable to QTextEdit or we have to track visited manually
-            linked = QString("<a href=\"%1\" style=\"color:%2\">").arg(href, linkColor.name());
+            linked = QString(R"(<a href="%1" style="color:%2">)").arg(href, linkColor.name());
 #endif
             linked += (escape(link) + "</a>" + escape(pre.mid(cutoff)));
             out.replace(x1, len, linked);
@@ -596,17 +596,16 @@ QString TextUtil::img2title(const QString &in)
 
 QString TextUtil::legacyFormat(const QString &in)
 {
-
     // enable *bold* stuff
     // //old code
-    // out=out.replace(QRegularExpression("(^[^<>\\s]*|\\s[^<>\\s]*)\\*(\\S+)\\*([^<>\\s]*\\s|[^<>\\s]*$)"),"\\1<b>*\\2*</b>\\3");
-    // out=out.replace(QRegularExpression("(^[^<>\\s\\/]*|\\s[^<>\\s\\/]*)\\/([^\\/\\s]+)\\/([^<>\\s\\/]*\\s|[^<>\\s\\/]*$)"),"\\1<i>/\\2/</i>\\3");
-    // out=out.replace(QRegularExpression("(^[^<>\\s]*|\\s[^<>\\s]*)_(\\S+)_([^<>\\s]*\\s|[^<>\\s]*$)"),"\\1<u>_\\2_</u>\\3");
+   //  out=out.replace(QRegularExpression(R"((^[^<>\s]*|\s[^<>\s]*)\*(\S+)\*([^<>\s]*\s|[^<>\s]*$))"), "\\1<b>*\\2*</b>\\3");
+   //  out=out.replace(QRegularExpression(R"((^[^<>\s\/]*|\s[^<>\s\/]*)\/([^\/\s]+)\/([^<>\s\/]*\s|[^<>\s\/]*$))"), "\\1<i>/\\2/</i>\\3");
+   //  out=out.replace(QRegularExpression(R"((^[^<>\s]*|\s[^<>\s]*)_(\S+)_([^<>\s]*\s|[^<>\s]*$))"), "\\1<u>_\\2_</u>\\3");
 
     QString out = in;
-    out = out.replace(QRegularExpression("(^|\\s|>)_(\\S+)_(?=<|\\s|$)"), "\\1<u>_\\2_</u>"); // underline inside _text_
-    out = out.replace(QRegularExpression("(^|\\s|>)\\*(\\S+)\\*(?=<|\\s|$)"), "\\1<b>*\\2*</b>"); // bold *text*
-    out = out.replace(QRegularExpression("(^|\\s|>)\\/(\\S+)\\/(?=<|\\s|$)"), "\\1<i>/\\2/</i>"); // italic /text/
+    out = out.replace(QRegularExpression(R"((^|\s|>)_(\S+)_(?=<|\s|$))"), "\\1<u>_\\2_</u>"); // underline inside _text_
+    out = out.replace(QRegularExpression(R"((^|\s|>)\*(\S+)\*(?=<|\s|$))"), "\\1<b>*\\2*</b>"); // bold *text*
+    out = out.replace(QRegularExpression(R"((^|\s|>)\/(\S+)\/(?=<|\s|$))"), "\\1<i>/\\2/</i>"); // italic /text/
 
     return out;
 }

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -191,6 +191,7 @@ QString TextUtil::rich2plain(const QString &in, bool collapseSpaces)
 QString TextUtil::resolveEntities(const QStringView &in)
 {
     QString out;
+    out.reserve(in.length());
 
     for (int i = 0; i < int(in.length()); ++i) {
         if (in[i] == '&') {

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -193,13 +193,13 @@ QString TextUtil::resolveEntities(const QStringView &in)
     QString out;
     out.reserve(in.length());
 
-    for (int i = 0; i < int(in.length()); ++i) {
+    for (qsizetype i = 0; i < int(in.length()); i++) {
         if (in[i] != '&') {
             out += in[i];
             continue;
         }
         // find a semicolon
-        int n = in.indexOf(';', i+1);
+        qsizetype n = in.indexOf(';', i+1);
         if (n == -1) {
             out += in[i];
             continue;

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -196,13 +196,10 @@ QString TextUtil::resolveEntities(const QStringView &in)
     for (int i = 0; i < int(in.length()); ++i) {
         if (in[i] == '&') {
             // find a semicolon
-            ++i;
-            int n = in.indexOf(';', i);
+            int n = in.indexOf(';', i+1);
             if (n == -1)
                 break;
-            auto type = in.mid(i, (n - i));
-
-            i = n; // should be n+1, but we'll let the loop increment do it
+            auto type = in.mid(i+1, (n - (i+1)));
 
             if (type == QLatin1String { "amp" })
                 out += '&';
@@ -216,6 +213,7 @@ QString TextUtil::resolveEntities(const QStringView &in)
                 out += '\'';
             else if (type == QLatin1String { "nbsp" })
                 out += char(0xa0);
+            i = n; // should be n+1, but we'll let the loop increment do it
         } else {
             out += in[i];
         }

--- a/src/textutil.cpp
+++ b/src/textutil.cpp
@@ -194,29 +194,29 @@ QString TextUtil::resolveEntities(const QStringView &in)
     out.reserve(in.length());
 
     for (int i = 0; i < int(in.length()); ++i) {
-        if (in[i] == '&') {
-            // find a semicolon
-            int n = in.indexOf(';', i+1);
-            if (n == -1)
-                break;
-            auto type = in.mid(i+1, (n - (i+1)));
-
-            if (type == QLatin1String { "amp" })
-                out += '&';
-            else if (type == QLatin1String { "lt" })
-                out += '<';
-            else if (type == QLatin1String { "gt" })
-                out += '>';
-            else if (type == QLatin1String { "quot" })
-                out += '\"';
-            else if (type == QLatin1String { "apos" })
-                out += '\'';
-            else if (type == QLatin1String { "nbsp" })
-                out += char(0xa0);
-            i = n; // should be n+1, but we'll let the loop increment do it
-        } else {
+        if (in[i] != '&') {
             out += in[i];
+            continue;
         }
+        // find a semicolon
+        int n = in.indexOf(';', i+1);
+        if (n == -1)
+            break;
+        auto type = in.mid(i+1, (n - (i+1)));
+
+        if (type == QLatin1String { "amp" })
+            out += '&';
+        else if (type == QLatin1String { "lt" })
+            out += '<';
+        else if (type == QLatin1String { "gt" })
+            out += '>';
+        else if (type == QLatin1String { "quot" })
+            out += '\"';
+        else if (type == QLatin1String { "apos" })
+            out += '\'';
+        else if (type == QLatin1String { "nbsp" })
+            out += char(0xa0);
+        i = n; // should be n+1, but we'll let the loop increment do it
     }
 
     return out;


### PR DESCRIPTION
I started the Psi with Valgrind (`valgrind --track-origins=yes  psi`) and on receiving MUC messages I got a lot of such warnings:
```
  Uninitialised value was created by a heap allocation
    at 0x4851E10: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4D9FC68: QArrayData::reallocateUnaligned(QArrayData*, unsigned long, unsigned long, QFlags<QArrayData::AllocationOption>) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.15)
    by 0x4E1FF21: QString::reallocData(unsigned int, bool) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.15)
    by 0x65A315: TextUtil::resolveEntities(QStringView const&) (in /usr/local/bin/psi)
    by 0x63872D: RTParse::next() (in /usr/local/bin/psi)
    by 0x65A58F: TextUtil::emoticonify(QString const&) (in /usr/local/bin/psi)
    by 0x4F4804: MessageView::formattedText() const (in /usr/local/bin/psi)
    by 0x69E8FB: ChatView::renderMucMessage(MessageView const&, QTextCursor&) (in /usr/local/bin/psi)
    by 0x6A603D: ChatView::dispatchMessage(MessageView const&) (in /usr/local/bin/psi)
    by 0x485D14: GCMainDlg::dispatchMessage(MessageView const&) (in /usr/local/bin/psi)
    by 0x488E82: GCMainDlg::appendMessage(XMPP::Message const&, bool) (in /usr/local/bin/psi)
    by 0x49457D: GCMainDlg::message(XMPP::Message const&, QSharedPointer<PsiEvent> const&) (in /usr/local/bin/psi)
```

I have no idea how to fix this but I checked the `TextUtil::resolveEntities` and it looks like it just tries to unescape XML sequences i.e. `&amp;` to `&`.
The same class has the method `unescape()` that does the same:
```c
    QString plain = escaped;
    plain.replace("&lt;", "<");
    plain.replace("&gt;", ">");
    plain.replace("&quot;", "\"");
    plain.replace("&amp;", "&");
    return plain;
```

If my guess is correct then the `resolveEntities()` has a bug: it won't work when the `&` doesn't mean an escape sequence e.g. `hello & bye`, it will return `hello `. So in the PR I fixed the bug and slightly improved its performance.

But instead we can just call that `unescape()` method:
```cpp
QString TextUtil::resolveEntities(const QStringView &in)
{
    QString out = in.toString();
    unescape(out);
    return out;
}
```

In fact it may work even faster but needs to be benchmarked. This is a critical for performance place (especially memory usage). So here is another branch with a simpler change https://github.com/stokito/psi/tree/resolveEntities_replace

Please select any variant.

But the Valgrind warning remains even with the change so the problem is probably somewhere in the `RTParse::next()` or `TextUtil::emoticonify()`.