### PR TITLE
doap: fix XEP link

### DIFF
--- a/psi.doap
+++ b/psi.doap
@@ -713,7 +713,7 @@
     <!-- XEP-0368: SRV records for XMPP over TLS -->
     <implements>
       <xmpp:SupportedXep>
-        <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0364.html'/>
+        <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0368.html'/>
         <xmpp:status>complete</xmpp:status>
         <xmpp:version>1.1.0</xmpp:version>
       </xmpp:SupportedXep>


### PR DESCRIPTION
XEP-0368 but link to was to 0364
Closes: #871
