### PR TITLE
Chat menu

### DIFF
--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -1033,7 +1033,6 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
     // #ifdef WHITEBOARDING
     //     ui_.toolbar->addAction(d->act_whiteboard);
     // #endif
-    ui_.toolbar->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Maximum);
 
     // Common actions
     d->act_send = new QAction(this);

--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -2621,9 +2621,6 @@ void GCMainDlg::buildMenu()
     // #endif
     d->pm_settings->addSeparator();
 
-    d->pm_settings->addAction(d->actions->action("gchat_icon"));
-    d->pm_settings->addAction(d->actions->action("gchat_templates"));
-    d->pm_settings->addAction(d->act_pastesend);
     d->pm_settings->addAction(d->act_nick);
     d->pm_settings->addAction(d->act_bookmark);
     d->pm_settings->addAction(d->actions->action("gchat_set_topic"));
@@ -2638,7 +2635,6 @@ void GCMainDlg::buildMenu()
         PluginManager::instance()->addGCToolBarButton(this, d->pm_settings, account(), jid().full());
     }
 #endif
-    d->pm_settings->addAction(d->actions->action("gchat_share_files"));
 }
 
 void GCMainDlg::chatEditCreated()

--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -975,6 +975,8 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
             connect(action, SIGNAL(triggered()), SLOT(pinTab()));
         } else if (name == QLatin1String("gchat_templates")) {
             action->setMenu(getTemplateMenu());
+        } else if (name == QLatin1String("gchat_set_topic")) {
+            connect(action, &QAction::triggered, this, &GCMainDlg::openTopic);
         }
     }
 
@@ -999,7 +1001,6 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
     addAction(d->act_mini_cmd);
 
     auto actSetTopic = d->actions->action("gchat_set_topic");
-    connect(actSetTopic, &IconAction::triggered, this, &GCMainDlg::openTopic);
     ui_.le_topic->addAction(actSetTopic);
 
     d->act_bookmark  = new IconAction(this);

--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -975,6 +975,8 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
             connect(action, SIGNAL(triggered()), SLOT(pinTab()));
         } else if (name == QLatin1String("gchat_templates")) {
             action->setMenu(getTemplateMenu());
+        } else if (name == QLatin1String("gchat_paste_send")) {
+            connect(action, SIGNAL(triggered()), SLOT(doPasteAndSend()));
         } else if (name == QLatin1String("gchat_set_topic")) {
             connect(action, &QAction::triggered, this, &GCMainDlg::openTopic);
         }
@@ -1019,8 +1021,7 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
     connect(bm, SIGNAL(conferencesChanged(QList<ConferenceBookmark>)), SLOT(updateMucName()));
     connect(bm, SIGNAL(bookmarksSaved()), SLOT(updateBookmarkIcon()));
 
-    d->act_pastesend = new IconAction(tr("Paste and Send"), "psi/action_paste_and_send", tr("Paste and Send"), 0, this);
-    connect(d->act_pastesend, SIGNAL(triggered()), SLOT(doPasteAndSend()));
+    d->act_pastesend = d->actions->action("gchat_paste_send");
 
     d->act_minimize = new QAction(this);
     connect(d->act_minimize, SIGNAL(triggered()), SLOT(doMinimize()));

--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -998,11 +998,12 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
     connect(d->act_mini_cmd, SIGNAL(triggered()), d, SLOT(doMiniCmd()));
     addAction(d->act_mini_cmd);
 
-    d->act_bookmark  = new IconAction(this);
     auto actSetTopic = d->actions->action("gchat_set_topic");
     connect(actSetTopic, &IconAction::triggered, this, &GCMainDlg::openTopic);
-    connect(d->act_bookmark, SIGNAL(triggered()), SLOT(doBookmark()));
     ui_.le_topic->addAction(actSetTopic);
+
+    d->act_bookmark  = new IconAction(this);
+    connect(d->act_bookmark, SIGNAL(triggered()), SLOT(doBookmark()));
     ui_.le_topic->addAction(d->act_bookmark);
 
     d->act_copy_muc_jid = new QAction(tr("Copy Groupchat JID"), this);

--- a/src/groupchatdlg.cpp
+++ b/src/groupchatdlg.cpp
@@ -1012,10 +1012,7 @@ GCMainDlg::GCMainDlg(PsiAccount *pa, const Jid &j, TabManager *tabManager) : Tab
     ui_.le_topic->addAction(d->act_copy_muc_jid);
 
     BookmarkManager *bm = account()->bookmarkManager();
-    d->act_bookmark->setVisible(bm->isAvailable());
-    if (bm->isAvailable()) {
-        updateBookmarkIcon();
-    }
+    updateBookmarkIcon();
     connect(bm, SIGNAL(availabilityChanged()), SLOT(updateBookmarkIcon()));
     connect(bm, SIGNAL(conferencesChanged(QList<ConferenceBookmark>)), SLOT(updateBookmarkIcon()));
     connect(bm, SIGNAL(conferencesChanged(QList<ConferenceBookmark>)), SLOT(updateMucName()));

--- a/src/groupchatdlg.ui
+++ b/src/groupchatdlg.ui
@@ -225,7 +225,7 @@
        <item>
         <widget class="QToolBar" name="toolbar">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+          <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/src/psiactionlist.cpp
+++ b/src/psiactionlist.cpp
@@ -499,6 +499,7 @@ void PsiActionList::Private::createChat()
         IconAction *actShareFiles = new IconAction(tr("Share Files"), "psi/share_file", tr("Share Files"), 0, this);
         IconAction *actPinTab     = new IconAction(tr("Pin/UnPin Tab"), "psi/pin", tr("Pin/UnPin Tab"), 0, this);
         IconAction *actTemplates  = new IconAction(tr("Templates"), "psi/action_templates", tr("Templates"), 0, this);
+        IconAction *actPasteSend = new IconAction(tr("Paste and Send"), "psi/action_paste_and_send", tr("Paste and Send"), 0, this);
 
         ActionNames actions[] = { { "chat_clear", actClear },
                                   { "chat_find", actFind },
@@ -515,6 +516,7 @@ void PsiActionList::Private::createChat()
                                   { "chat_share_files", actShareFiles },
                                   { "chat_pin_tab", actPinTab },
                                   { "chat_templates", actTemplates },
+                                  { "chat_paste_send", actPasteSend },
                                   { "", nullptr } };
 
         createActionList(tr("Chat basic buttons"), Actions_Chat, actions);
@@ -537,6 +539,7 @@ void PsiActionList::Private::createGroupchat()
         IconAction *actShareFiles = new IconAction(tr("Share Files"), "psi/share_file", tr("Share Files"), 0, this);
         IconAction *actPinTab     = new IconAction(tr("Pin/UnPin Tab"), "psi/pin", tr("Pin/UnPin Tab"), 0, this);
         IconAction *actTemplates  = new IconAction(tr("Templates"), "psi/action_templates", tr("Templates"), 0, this);
+        IconAction *actPasteSend = new IconAction(tr("Paste and Send"), "psi/action_paste_and_send", tr("Paste and Send"), 0, this);
 
         IconAction *actSetTopic  = new IconAction(tr("Set Topic"), QLatin1String("psi/topic"), tr("Set Topic"), 0, this);
 
@@ -550,6 +553,7 @@ void PsiActionList::Private::createGroupchat()
                                   { "gchat_pin_tab", actPinTab },
                                   { "gchat_templates", actTemplates },
                                   { "gchat_set_topic", actSetTopic },
+                                  { "gchat_paste_send", actPasteSend },
                                   { "", nullptr } };
 
         createActionList(tr("Groupchat basic buttons"), Actions_Groupchat, actions);

--- a/src/psiactionlist.cpp
+++ b/src/psiactionlist.cpp
@@ -538,9 +538,7 @@ void PsiActionList::Private::createGroupchat()
         IconAction *actPinTab     = new IconAction(tr("Pin/UnPin Tab"), "psi/pin", tr("Pin/UnPin Tab"), 0, this);
         IconAction *actTemplates  = new IconAction(tr("Templates"), "psi/action_templates", tr("Templates"), 0, this);
 
-        QString     setTopicText = tr("Set Topic");
-        IconAction *actSetTopic  = new IconAction(setTopicText, QLatin1String("psi/topic"), setTopicText, 0, this);
-        actSetTopic->setToolTip(setTopicText);
+        IconAction *actSetTopic  = new IconAction(tr("Set Topic"), QLatin1String("psi/topic"), tr("Set Topic"), 0, this);
 
         ActionNames actions[] = { { "gchat_info", actInfo },
                                   { "gchat_clear", actClear },

--- a/src/psichatdlg.cpp
+++ b/src/psichatdlg.cpp
@@ -1002,11 +1002,6 @@ void PsiChatDlg::buildMenu()
     pm_settings_->addAction(actions_->action("chat_clear"));
     pm_settings_->addSeparator();
 
-    pm_settings_->addAction(actions_->action("chat_icon"));
-    pm_settings_->addAction(actions_->action("chat_templates"));
-    pm_settings_->addAction(act_pastesend_);
-    pm_settings_->addAction(actions_->action("chat_share_files"));
-    pm_settings_->addAction(actions_->action("chat_file"));
     if (AvCallManager::isSupported()) {
         pm_settings_->addAction(actions_->action("chat_voice"));
     }

--- a/src/psichatdlg.cpp
+++ b/src/psichatdlg.cpp
@@ -319,8 +319,7 @@ void PsiChatDlg::initUi()
     connect(ui_.log, &ChatView::quote, ui_.mle->chatEdit(), &ChatEdit::insertAsQuote);
     connect(ui_.log, &ChatView::editMessageRequested, ui_.mle->chatEdit(), &ChatEdit::startCorrection);
 
-    act_pastesend_ = new IconAction(tr("Paste and Send"), "psi/action_paste_and_send", tr("Paste and Send"), 0, this);
-    connect(act_pastesend_, SIGNAL(triggered()), SLOT(doPasteAndSend()));
+    act_pastesend_ = actions_->action("chat_paste_send");
 
     ui_.log->realTextWidget()->installEventFilter(this);
     ui_.mini_prompt->hide();
@@ -566,6 +565,8 @@ void PsiChatDlg::initToolButtons()
             connect(action, SIGNAL(triggered()), SLOT(pinTab()));
         } else if (name == "chat_templates") {
             action->setMenu(getTemplateMenu());
+        } else if (name == "chat_paste_send") {
+            connect(action, SIGNAL(triggered()), SLOT(doPasteAndSend()));
         }
     }
 


### PR DESCRIPTION
In the Chat and room chat window on the top right there is a menu.
The menu contains some basic actions like "user info" or "change nickname".
But it also has items that are related to message editing: select a smile, paste and send.
I removed them because this is wrong place for them. A user must see the editor and buttons should be near there.
The "Paste and send" action wasn't available for selection in the Options / Toolbars. I fixed this too.
The code is really complicated in the place, I also made some minor refactoring.