### PR TITLE
tray: add more options

### DIFF
--- a/src/mainwin.cpp
+++ b/src/mainwin.cpp
@@ -1179,8 +1179,8 @@ void MainWin::buildTrayMenu()
                 return;
             }
 
-            // Workaround for some unknow bug. likely this one https://bugreports.qt.io/browse/QTBUG-63187
-            // replaces possible svg icon with QPixmap
+            // Workaround for some unknown bug, likely this one https://bugreports.qt.io/browse/QTBUG-63187
+            // Replaces the possible SVG icon with QPixmap
             auto actionCopy
                 = new QAction(QIcon(action->icon().pixmap(iconSize, iconSize)), action->text(), d->trayMenu);
             actionCopy->setCheckable(action->isCheckable());
@@ -1197,8 +1197,15 @@ void MainWin::buildTrayMenu()
             d->trayMenu->addAction(actionCopy);
         };
 
-        const QStringList _actions = { "status_online", "status_chat",    "status_away", "status_xa",
-                                       "status_dnd",    "status_offline", "separator",   "menu_options" };
+        const QStringList _actions = {
+            "status_online", "status_chat", "status_away", "status_xa", "status_dnd", "status_offline", "separator",
+            "menu_play_sounds", "menu_options",
+            "menu_add_contact",
+#ifdef GROUPCHAT
+            "menu_join_groupchat",
+#endif
+            "menu_new_message",
+            "menu_quit" };
         for (const QString &actionName : _actions) {
             addWrappedAction(actionName);
         }


### PR DESCRIPTION
Added new menu items for the tray icon:

- "menu_play_sounds" added right after statuses to Mute sounds for those who don't use the DND status.
- "menu_add_contact" to quickly add a new contact.
- "menu_join_groupchat" to join a group chat.
- "menu_new_message" to compose a message. This is an old UI "Single message" window instead of dialog, but I hope later it can be improved.
