### PR TITLE
Move modern Windows packaging to MSVC/Qt6 WebEngine

### DIFF
--- a/.github/workflows/windows-msvc-qt6-profile.yml
+++ b/.github/workflows/windows-msvc-qt6-profile.yml
@@ -45,6 +45,14 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --recursive --depth=1
 
+      - name: Restore compiler cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .ccache
+          key: windows-msvc-qt6-ccache-${{ github.sha }}
+          restore-keys: |
+            windows-msvc-qt6-ccache-
+
       - name: Install Qt 6.11 + WebEngine
         uses: jurplel/install-qt-action@v4
         with:
@@ -77,7 +85,7 @@ jobs:
 
       - name: Install packaging tools
         run: |
-          choco install ninja nsis --no-progress -y
+          choco install ccache ninja nsis --no-progress -y
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           "${env:ProgramFiles(x86)}\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
@@ -123,6 +131,11 @@ jobs:
             throw
           }
 
+      - name: Show compiler cache statistics
+        run: |
+          ccache --show-stats
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload release packages
         uses: actions/upload-artifact@v4
         with:
@@ -145,3 +158,10 @@ jobs:
             artifacts/*.txt
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Save compiler cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .ccache
+          key: windows-msvc-qt6-ccache-${{ github.sha }}

--- a/.github/workflows/windows-msvc-qt6-profile.yml
+++ b/.github/workflows/windows-msvc-qt6-profile.yml
@@ -1,0 +1,147 @@
+name: Windows MSVC Qt6 profile
+
+on:
+  workflow_call:
+    inputs:
+      sdk_tag:
+        description: Dependency SDK release tag
+        required: false
+        default: windows-sdk-msvc-qt6-v1
+        type: string
+      sdk_archive:
+        description: Dependency SDK release asset
+        required: false
+        default: psi-windows-sdk-msvc-qt6.zip
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  QT_SERIES: "6.11.*"
+  AQT_WINDOWS_QT611_SOURCE: "git+https://github.com/miurahr/aqtinstall.git@refs/pull/1000/head"
+
+jobs:
+  build:
+    name: modern MSVC Qt6 x64
+    runs-on: windows-2022
+    timeout-minutes: 120
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Fetch Psi history
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          submodules: false
+
+      - name: Fetch bundled sources shallowly
+        shell: bash
+        run: |
+          set -euo pipefail
+          git submodule sync --recursive
+          git submodule update --init --recursive --depth=1
+
+      - name: Install Qt 6.11 + WebEngine
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_SERIES }}
+          arch: win64_msvc2022_64
+          modules: qtmultimedia qtwebchannel qtpositioning qtwebengine qtimageformats
+          aqtsource: ${{ env.AQT_WINDOWS_QT611_SOURCE }}
+          cache: true
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Verify Windows 10 compile baseline
+        run: |
+          @'
+          #include <windows.h>
+          #if _WIN32_WINNT != 0x0A00
+          #error _WIN32_WINNT baseline mismatch
+          #endif
+          #if WINVER != 0x0A00
+          #error WINVER baseline mismatch
+          #endif
+          int main() { return 0; }
+          '@ | Set-Content winver-check.cpp -Encoding ascii
+
+          cl.exe /nologo /c /D_WIN32_WINNT=0x0A00 /DWINVER=0x0A00 winver-check.cpp
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Install packaging tools
+        run: |
+          choco install ninja nsis --no-progress -y
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "${env:ProgramFiles(x86)}\NSIS" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Download dependency SDK
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SDK_TAG: ${{ inputs.sdk_tag }}
+          SDK_ARCHIVE: ${{ inputs.sdk_archive }}
+        run: |
+          New-Item -ItemType Directory -Force sdk-artifact | Out-Null
+          gh release download $env:SDK_TAG `
+            --repo $env:GITHUB_REPOSITORY `
+            --pattern $env:SDK_ARCHIVE `
+            --dir sdk-artifact
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path "sdk-artifact\$env:SDK_ARCHIVE")) {
+            throw "SDK asset is missing: $env:SDK_TAG/$env:SDK_ARCHIVE"
+          }
+
+      - name: Extract SDK
+        env:
+          SDK_ARCHIVE: ${{ inputs.sdk_archive }}
+        run: |
+          New-Item -ItemType Directory -Force sdk | Out-Null
+          Expand-Archive "sdk-artifact\$env:SDK_ARCHIVE" sdk -Force
+          if (-not (Test-Path sdk\SDK-MANIFEST.txt)) {
+            throw 'SDK manifest missing'
+          }
+          if (-not (Test-Path sdk\lib\cmake\Qt6Keychain\Qt6KeychainConfig.cmake)) {
+            throw 'Qt6Keychain package missing from SDK'
+          }
+
+      - name: Build and package modern profile
+        run: |
+          New-Item -ItemType Directory -Force artifacts | Out-Null
+          try {
+            & packaging\windows\build_profile_msvc.ps1 `
+              -SdkDir "$pwd\sdk" `
+              -OutputDir "$pwd\artifacts" 2>&1 |
+              Tee-Object -FilePath artifacts\build-modern.log
+          } catch {
+            $_ | Out-String | Tee-Object -FilePath artifacts\status-modern.txt
+            throw
+          }
+
+      - name: Upload release packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: psi-windows-modern-x64
+          path: |
+            artifacts/*.zip
+            artifacts/*-setup.exe
+            artifacts/dependencies-*.txt
+            artifacts/version-*.txt
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload packaging diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: psi-windows-modern-diagnostics
+          path: |
+            artifacts/*.log
+            artifacts/*.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/windows-msvc-qt6.yml
+++ b/.github/workflows/windows-msvc-qt6.yml
@@ -1,25 +1,28 @@
-name: Windows legacy MSYS2 Qt5 CI
+name: Windows modern MSVC Qt6 CI
 
 on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - '*'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: windows-legacy-msys2-qt5-${{ github.ref }}
+  group: windows-modern-msvc-qt6-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  SDK_TAG: windows-sdk-msys2-qt5-v1
-  SDK_ARCHIVE: psi-windows-sdk-msys2-qt5.zip
+  SDK_TAG: windows-sdk-msvc-qt6-v1
+  SDK_ARCHIVE: psi-windows-sdk-msvc-qt6.zip
 
 jobs:
   check-sdk:
-    name: Check legacy dependency SDK
+    name: Check modern dependency SDK
     runs-on: ubuntu-24.04
     outputs:
       exists: ${{ steps.check.outputs.exists }}
@@ -45,18 +48,18 @@ jobs:
           fi
 
   build-sdk:
-    name: Build missing legacy dependency SDK
+    name: Build missing modern dependency SDK
     needs: check-sdk
     if: needs.check-sdk.outputs.exists != 'true'
     permissions:
       contents: write
-    uses: ./.github/workflows/windows-sdk-msys2-qt5.yml
+    uses: ./.github/workflows/windows-sdk-msvc-qt6.yml
     with:
-      sdk_tag: windows-sdk-msys2-qt5-v1
+      sdk_tag: windows-sdk-msvc-qt6-v1
       force_rebuild: false
 
-  legacy-win7:
-    name: Build legacy Windows 7 x64 package
+  modern:
+    name: Build modern Windows 10/11 x64 package
     needs:
       - check-sdk
       - build-sdk
@@ -66,9 +69,7 @@ jobs:
       (needs.check-sdk.outputs.exists == 'true' || needs.build-sdk.result == 'success')
     permissions:
       contents: read
-    uses: ./.github/workflows/windows-msys2-qt5-profile.yml
+    uses: ./.github/workflows/windows-msvc-qt6-profile.yml
     with:
-      profile: legacy-win7
-      allow_failure: true
-      sdk_tag: windows-sdk-msys2-qt5-v1
-      sdk_archive: psi-windows-sdk-msys2-qt5.zip
+      sdk_tag: windows-sdk-msvc-qt6-v1
+      sdk_archive: psi-windows-sdk-msvc-qt6.zip

--- a/.github/workflows/windows-sdk-msvc-qt6.yml
+++ b/.github/workflows/windows-sdk-msvc-qt6.yml
@@ -293,7 +293,7 @@ jobs:
           else
             gh release create "$SDK_TAG" "$archive" \
               --repo "$GITHUB_REPOSITORY" \
-              --target master \
+              --target infra/windows-sdk-releases \
               --title "Psi Windows SDK (MSVC 2022 / Qt6)" \
               --notes "Development/runtime SDK for the modern Windows build. Qt itself is installed from the official Qt binary repository; this SDK contains OpenSSL, zlib, Hunspell, minizip and static Qt6Keychain."
           fi

--- a/.github/workflows/windows-sdk-msvc-qt6.yml
+++ b/.github/workflows/windows-sdk-msvc-qt6.yml
@@ -1,0 +1,299 @@
+name: Windows SDK MSVC Qt6
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdk_tag:
+        description: SDK release tag
+        required: false
+        default: windows-sdk-msvc-qt6-v1
+        type: string
+      force_rebuild:
+        description: Rebuild and replace the SDK asset even if it already exists
+        required: false
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      sdk_tag:
+        description: SDK release tag
+        required: false
+        default: windows-sdk-msvc-qt6-v1
+        type: string
+      force_rebuild:
+        description: Rebuild and replace the SDK asset even if it already exists
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: windows-sdk-msvc-qt6-${{ inputs.sdk_tag }}
+  cancel-in-progress: false
+
+env:
+  QT_SERIES: "6.11.*"
+  QTKEYCHAIN_TAG: "0.17.0"
+  SDK_ARCHIVE: psi-windows-sdk-msvc-qt6.zip
+  AQT_WINDOWS_QT611_SOURCE: "git+https://github.com/miurahr/aqtinstall.git@refs/pull/1000/head"
+
+jobs:
+  check:
+    name: Check SDK release
+    runs-on: ubuntu-24.04
+    outputs:
+      need_build: ${{ steps.check.outputs.need_build }}
+
+    steps:
+      - name: Check release asset
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SDK_TAG: ${{ inputs.sdk_tag }}
+          FORCE_REBUILD: ${{ inputs.force_rebuild }}
+        run: |
+          set -euo pipefail
+          if [[ "$FORCE_REBUILD" == "true" ]]; then
+            echo "need_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          assets="$(gh release view "$SDK_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json assets \
+            --jq '.assets[].name' 2>/dev/null || true)"
+
+          if grep -Fxq "$SDK_ARCHIVE" <<< "$assets"; then
+            echo "SDK $SDK_TAG/$SDK_ARCHIVE already exists"
+            echo "need_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "SDK $SDK_TAG/$SDK_ARCHIVE is missing"
+            echo "need_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build MSVC Qt6 dependency SDK
+    needs: check
+    if: needs.check.outputs.need_build == 'true'
+    runs-on: windows-2022
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Install Qt 6.11
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_SERIES }}
+          arch: win64_msvc2022_64
+          aqtsource: ${{ env.AQT_WINDOWS_QT611_SOURCE }}
+          cache: true
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Resolve vcpkg cache key
+        id: vcpkg-key
+        run: |
+          $revision = (git -C $env:VCPKG_INSTALLATION_ROOT rev-parse HEAD).Trim()
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+          $toolset = (Get-Content (Join-Path $vsPath 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt') -Raw).Trim()
+          "vcpkg=$revision" >> $env:GITHUB_OUTPUT
+          "msvc=$toolset" >> $env:GITHUB_OUTPUT
+
+      - name: Restore vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/vcpkg-binary-cache
+          key: psi-msvc-qt6-sdk-vcpkg-${{ steps.vcpkg-key.outputs.vcpkg }}-${{ steps.vcpkg-key.outputs.msvc }}-x64-windows-v1
+
+      - name: Install native dependency packages
+        run: |
+          $cache = Join-Path $env:RUNNER_TEMP 'vcpkg-binary-cache'
+          New-Item -ItemType Directory -Force -Path $cache | Out-Null
+          $env:VCPKG_BINARY_SOURCES = "clear;files,$cache,readwrite"
+
+          vcpkg install `
+            openssl:x64-windows `
+            zlib:x64-windows `
+            hunspell:x64-windows `
+            minizip:x64-windows
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stage vcpkg development and runtime files
+        run: |
+          $installed = Join-Path $env:VCPKG_INSTALLATION_ROOT 'installed\x64-windows'
+          New-Item -ItemType Directory -Force sdk, sdk\include, sdk\lib, sdk\bin, sdk\share\licenses | Out-Null
+
+          Copy-Item (Join-Path $installed 'include\*') sdk\include -Recurse -Force
+          Copy-Item (Join-Path $installed 'lib\*.lib') sdk\lib -Force
+          Copy-Item (Join-Path $installed 'bin\*.dll') sdk\bin -Force
+
+          # Psi's historical FindHunspell.cmake also accepts a flat include
+          # layout on Windows. Keep that compatibility facade in the SDK.
+          Copy-Item (Join-Path $installed 'include\hunspell\*.h*') sdk\include -Force
+
+          foreach ($package in @('openssl', 'zlib', 'hunspell', 'minizip', 'libiconv')) {
+            $copyright = Join-Path $installed "share\$package\copyright"
+            if (Test-Path $copyright) {
+              $target = Join-Path 'sdk\share\licenses' $package
+              New-Item -ItemType Directory -Force $target | Out-Null
+              Copy-Item $copyright (Join-Path $target 'COPYRIGHT')
+            }
+          }
+
+          if (-not (Get-ChildItem sdk\lib -File | Where-Object Name -Match 'hunspell.*\.lib$')) {
+            throw 'Hunspell import library missing from SDK'
+          }
+          if (-not (Get-ChildItem sdk\lib -File | Where-Object Name -Match 'minizip.*\.lib$')) {
+            throw 'minizip import library missing from SDK'
+          }
+          if (-not (Get-ChildItem sdk\lib -File | Where-Object Name -Match 'libcrypto.*\.lib$')) {
+            throw 'OpenSSL crypto import library missing from SDK'
+          }
+
+      - name: Build static Qt6Keychain
+        run: |
+          git clone --depth 1 --branch $env:QTKEYCHAIN_TAG https://github.com/frankosterfeld/qtkeychain.git qtkeychain
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          cmake -S qtkeychain -B qtkeychain-build -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_INSTALL_PREFIX="$pwd/sdk" `
+            -DCMAKE_INSTALL_LIBDIR=lib `
+            -DCMAKE_INSTALL_INCLUDEDIR=include `
+            "-DCMAKE_PREFIX_PATH=$env:QT_ROOT_DIR" `
+            -DBUILD_SHARED_LIBS=OFF `
+            -DBUILD_WITH_QT6=ON `
+            -DBUILD_TESTING=OFF `
+            -DBUILD_TEST_APPLICATION=OFF `
+            -DBUILD_QTQUICK_DEMO=OFF `
+            -DBUILD_TRANSLATIONS=OFF `
+            -DLIBSECRET_SUPPORT=OFF
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          cmake --build qtkeychain-build --parallel 4
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cmake --install qtkeychain-build
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          if (-not (Test-Path sdk\lib\cmake\Qt6Keychain\Qt6KeychainConfig.cmake)) {
+            throw 'Qt6Keychain CMake package missing'
+          }
+          if (-not (Test-Path sdk\lib\qt6keychain.lib)) {
+            throw 'Static Qt6Keychain library missing'
+          }
+
+      - name: Verify relocated SDK consumer
+        run: |
+          Move-Item sdk relocated-sdk
+          New-Item -ItemType Directory consumer | Out-Null
+          @'
+          cmake_minimum_required(VERSION 3.25)
+          project(psi_msvc_sdk_consumer LANGUAGES CXX)
+          find_package(Qt6 REQUIRED COMPONENTS Core)
+          find_package(Qt6Keychain CONFIG REQUIRED)
+          find_package(OpenSSL REQUIRED)
+          find_package(ZLIB REQUIRED)
+          add_executable(psi-sdk-consumer main.cpp)
+          target_link_libraries(psi-sdk-consumer PRIVATE
+              Qt6::Core
+              Qt6Keychain::Qt6Keychain
+              OpenSSL::Crypto
+              ZLIB::ZLIB)
+          '@ | Set-Content consumer\CMakeLists.txt -Encoding utf8
+          @'
+          #include <openssl/crypto.h>
+          #include <qt6keychain/keychain.h>
+          #include <zlib.h>
+
+          int main()
+          {
+              QKeychain::ReadPasswordJob job(QStringLiteral("psi-sdk-test"));
+              return (OpenSSL_version_num() != 0 && zlibVersion()[0] != '\0'
+                      && !job.service().isEmpty()) ? 0 : 1;
+          }
+          '@ | Set-Content consumer\main.cpp -Encoding utf8
+
+          cmake -S consumer -B consumer-build -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            "-DCMAKE_PREFIX_PATH=$pwd/relocated-sdk;$env:QT_ROOT_DIR" `
+            "-DQt6Keychain_DIR=$pwd/relocated-sdk/lib/cmake/Qt6Keychain" `
+            "-DOPENSSL_ROOT_DIR=$pwd/relocated-sdk"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cmake --build consumer-build --parallel 2
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $env:PATH = "$pwd\relocated-sdk\bin;$env:QT_ROOT_DIR\bin;$env:PATH"
+          & "$pwd\consumer-build\psi-sdk-consumer.exe"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Move-Item relocated-sdk sdk
+
+      - name: Write SDK manifest and archive
+        run: |
+          $vcpkgRevision = (git -C $env:VCPKG_INSTALLATION_ROOT rev-parse HEAD).Trim()
+          $qtVersion = (& "$env:QT_ROOT_DIR\bin\qmake.exe" -query QT_VERSION).Trim()
+          @"
+          Psi Windows SDK
+          =================
+          Build environment: MSVC 2022 / Qt $qtVersion
+          Target: Windows x64
+          QtKeychain source: frankosterfeld/qtkeychain $env:QTKEYCHAIN_TAG (static)
+          vcpkg revision: $vcpkgRevision
+          vcpkg packages: openssl, zlib, hunspell, minizip and transitive runtime dependencies
+          SDK purpose: non-Qt development/runtime dependencies for the modern Psi MSVC/Qt6 build
+          "@ | Set-Content sdk\SDK-MANIFEST.txt -Encoding utf8
+
+          if (Test-Path $env:SDK_ARCHIVE) { Remove-Item $env:SDK_ARCHIVE -Force }
+          Compress-Archive -Path sdk\* -DestinationPath $env:SDK_ARCHIVE -CompressionLevel Optimal
+          if (-not (Test-Path $env:SDK_ARCHIVE)) { throw 'SDK archive was not created' }
+
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: psi-windows-sdk-msvc-qt6
+          path: ${{ env.SDK_ARCHIVE }}
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish SDK release
+    needs:
+      - check
+      - build
+    if: needs.check.outputs.need_build == 'true' && needs.build.result == 'success'
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download SDK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: psi-windows-sdk-msvc-qt6
+          path: release
+
+      - name: Create or update SDK release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SDK_TAG: ${{ inputs.sdk_tag }}
+        run: |
+          set -euo pipefail
+          archive="release/$SDK_ARCHIVE"
+          test -f "$archive"
+
+          if gh release view "$SDK_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$SDK_TAG" "$archive" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
+          else
+            gh release create "$SDK_TAG" "$archive" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target master \
+              --title "Psi Windows SDK (MSVC 2022 / Qt6)" \
+              --notes "Development/runtime SDK for the modern Windows build. Qt itself is installed from the official Qt binary repository; this SDK contains OpenSSL, zlib, Hunspell, minizip and static Qt6Keychain."
+          fi

--- a/.github/workflows/windows-sdk-msys2-qt5.yml
+++ b/.github/workflows/windows-sdk-msys2-qt5.yml
@@ -277,7 +277,7 @@ jobs:
           else
             gh release create "$SDK_TAG" "$archive" \
               --repo "$GITHUB_REPOSITORY" \
-              --target master \
+              --target infra/windows-sdk-releases \
               --title "Psi Windows SDK (MSYS2 MINGW64 / Qt5)" \
               --notes "Development/runtime SDK for dependencies not supplied as suitable Qt5 packages by MSYS2. Combine this archive with the MSYS2 packages listed in SDK-MANIFEST.txt."
           fi

--- a/cmake/modules/get-version.cmake
+++ b/cmake/modules/get-version.cmake
@@ -53,9 +53,10 @@ endfunction()
 
 function(obtain_git_version GIT_VERSION GIT_FULL_VERSION)
     if(EXISTS "${PROJECT_SOURCE_DIR}/\.git" AND (NOT IS_SNAPSHOT))
-        # Infrastructure tags (for example Windows SDK releases) must not
-        # become the Psi application version.
-        run_git(MAIN_VER describe --tags --abbrev=0 --exclude "windows-sdk-*")
+        # Only application/release tags are valid version anchors. Infrastructure
+        # tags (Windows SDKs, nightly plumbing, etc.) must never become Psi's
+        # version or the base of its revision count.
+        run_git(MAIN_VER describe --tags --abbrev=0 --match "[0-9]*")
         if(MAIN_VER)
             set(APP_VERSION "${MAIN_VER}" PARENT_SCOPE)
             set(${GIT_VERSION} ${MAIN_VER} PARENT_SCOPE)

--- a/cmake/modules/get-version.cmake
+++ b/cmake/modules/get-version.cmake
@@ -53,10 +53,7 @@ endfunction()
 
 function(obtain_git_version GIT_VERSION GIT_FULL_VERSION)
     if(EXISTS "${PROJECT_SOURCE_DIR}/\.git" AND (NOT IS_SNAPSHOT))
-        # Only application/release tags are valid version anchors. Infrastructure
-        # tags (Windows SDKs, nightly plumbing, etc.) must never become Psi's
-        # version or the base of its revision count.
-        run_git(MAIN_VER describe --tags --abbrev=0 --match "[0-9]*")
+        run_git(MAIN_VER describe --tags --abbrev=0)
         if(MAIN_VER)
             set(APP_VERSION "${MAIN_VER}" PARENT_SCOPE)
             set(${GIT_VERSION} ${MAIN_VER} PARENT_SCOPE)

--- a/packaging/windows/build_profile_msvc.ps1
+++ b/packaging/windows/build_profile_msvc.ps1
@@ -29,6 +29,13 @@ $sdkDir = (Resolve-Path $SdkDir).Path
 New-Item -ItemType Directory -Force $OutputDir | Out-Null
 $outputDir = (Resolve-Path $OutputDir).Path
 
+$ccache = (Get-Command ccache.exe -ErrorAction Stop).Source
+$ccacheDir = Join-Path $sourceDir '.ccache'
+New-Item -ItemType Directory -Force $ccacheDir | Out-Null
+$env:CCACHE_DIR = $ccacheDir
+Invoke-Checked $ccache --max-size=1G
+Invoke-Checked $ccache --zero-stats
+
 $buildDir = Join-Path $sourceDir 'build-msvc-modern'
 $stageDir = Join-Path $sourceDir 'package-msvc-modern'
 $l10nDir = Join-Path $sourceDir '.packaging-psi-l10n-msvc-modern'
@@ -64,6 +71,9 @@ $configureArgs = @(
     '-DQT_DEFAULT_MAJOR_VERSION=6',
     '-DUSE_QT6=ON',
     '-DUSE_MXE=OFF',
+    '-DUSE_CCACHE=OFF',
+    '-DCMAKE_C_COMPILER_LAUNCHER=ccache',
+    '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache',
     '-DCHAT_TYPE=WEBENGINE',
     '-DBUNDLED_IRIS=ON',
     '-DBUNDLED_IRIS_ALL=ON',
@@ -125,7 +135,7 @@ Invoke-Checked python packaging/windows/prepare_package_msvc.py `
     --qt-conf (Join-Path $sourceDir 'win32\qt.conf') `
     --report $report
 
-$baseTag = (git describe --tags --abbrev=0 --exclude 'windows-sdk-*').Trim()
+$baseTag = (git describe --tags --abbrev=0).Trim()
 if (-not $baseTag) {
     throw 'Could not determine the base Psi version tag'
 }

--- a/packaging/windows/build_profile_msvc.ps1
+++ b/packaging/windows/build_profile_msvc.ps1
@@ -213,11 +213,11 @@ if ($needsVcRedist) {
 Remove-Item $zipFile, $setupFile -Force -ErrorAction SilentlyContinue
 Push-Location $stageDir
 try {
-    Invoke-Checked cmake -E tar cf $zipFile --format=zip .
+    Invoke-Checked cmake '-E' tar cf $zipFile --format=zip .
 } finally {
     Pop-Location
 }
-Invoke-Checked cmake -E tar tf $zipFile
+Invoke-Checked cmake '-E' tar tf $zipFile
 
 $makensis = (Get-Command makensis.exe -ErrorAction Stop).Source
 $nsisArgs = @()

--- a/packaging/windows/build_profile_msvc.ps1
+++ b/packaging/windows/build_profile_msvc.ps1
@@ -1,0 +1,236 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SdkDir,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDir
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FilePath failed with exit code $LASTEXITCODE"
+    }
+}
+
+$sourceDir = (Get-Location).Path
+$sdkDir = (Resolve-Path $SdkDir).Path
+New-Item -ItemType Directory -Force $OutputDir | Out-Null
+$outputDir = (Resolve-Path $OutputDir).Path
+
+$buildDir = Join-Path $sourceDir 'build-msvc-modern'
+$stageDir = Join-Path $sourceDir 'package-msvc-modern'
+$l10nDir = Join-Path $sourceDir '.packaging-psi-l10n-msvc-modern'
+$report = Join-Path $outputDir 'dependencies-modern.txt'
+
+Remove-Item $buildDir, $stageDir, $l10nDir -Recurse -Force -ErrorAction SilentlyContinue
+
+# Psi translations live in psi-l10n. Keep the release package independent of
+# whatever translation checkout happens to exist in the source workspace.
+Invoke-Checked git clone --depth 1 --filter=blob:none --sparse `
+    https://github.com/psi-im/psi-l10n.git $l10nDir
+Invoke-Checked git -C $l10nDir sparse-checkout set translations
+$l10nRevision = (git -C $l10nDir rev-parse HEAD).Trim()
+
+$qtKeychainDir = Join-Path $sdkDir 'lib\cmake\Qt6Keychain'
+if (-not (Test-Path (Join-Path $qtKeychainDir 'Qt6KeychainConfig.cmake'))) {
+    throw "Qt6Keychain SDK is missing: $qtKeychainDir"
+}
+
+$configureLog = Join-Path $outputDir 'configure-modern.log'
+$configureArgs = @(
+    '-S', '.',
+    '-B', $buildDir,
+    '-G', 'Ninja',
+    '-DCMAKE_BUILD_TYPE=Release',
+    "-DCMAKE_INSTALL_PREFIX=$stageDir",
+    "-DCMAKE_PREFIX_PATH=$sdkDir;$env:QT_ROOT_DIR",
+    "-DSDK_PATH=$sdkDir",
+    "-DQt6Keychain_DIR=$qtKeychainDir",
+    "-DTRANSLATIONS_DIR=$l10nDir\translations",
+    '-DCMAKE_C_FLAGS=/D_WIN32_WINNT=0x0A00 /DWINVER=0x0A00',
+    '-DCMAKE_CXX_FLAGS=/D_WIN32_WINNT=0x0A00 /DWINVER=0x0A00',
+    '-DQT_DEFAULT_MAJOR_VERSION=6',
+    '-DUSE_QT6=ON',
+    '-DUSE_MXE=OFF',
+    '-DCHAT_TYPE=WEBENGINE',
+    '-DBUNDLED_IRIS=ON',
+    '-DBUNDLED_IRIS_ALL=ON',
+    '-DIRIS_BUNDLED_QCA_GIT_TAG=v3.0.1',
+    '-DENABLE_OMEMO=ON',
+    '-DUSE_HUNSPELL=ON',
+    '-DUSE_KEYCHAIN=ON',
+    '-DBUNDLED_KEYCHAIN=OFF',
+    "-DOPENSSL_ROOT_DIR=$sdkDir",
+    '-DOPENSSL_USE_STATIC_LIBS=OFF',
+    "-DHUNSPELL_ROOT=$sdkDir",
+    "-DMINIZIP_ROOT=$sdkDir",
+    '-DBUILD_TESTING=OFF',
+    '-DENABLE_PLUGINS=OFF',
+    '-DBUILD_PSIMEDIA=OFF',
+    '-DONLY_BINARY=OFF',
+    '-DINSTALL_EXTRA_FILES=ON'
+)
+
+& cmake @configureArgs 2>&1 | Tee-Object -FilePath $configureLog
+if ($LASTEXITCODE -ne 0) {
+    throw "CMake configure failed with exit code $LASTEXITCODE"
+}
+
+$configureText = Get-Content $configureLog -Raw
+foreach ($required in @(
+    'Chatlog type - QtWebEngine',
+    'BUNDLED_IRIS_ALL - ENABLED',
+    'Psi SDK Found at',
+    'Qt6 found'
+)) {
+    if ($configureText -notmatch [regex]::Escape($required)) {
+        throw "Expected configure marker was not found: $required"
+    }
+}
+
+Invoke-Checked cmake --build $buildDir --parallel 4
+Invoke-Checked cmake --install $buildDir
+
+$psiExe = Join-Path $stageDir 'psi.exe'
+if (-not (Test-Path $psiExe)) {
+    throw "Installed Psi executable is missing: $psiExe"
+}
+
+$translation = Get-ChildItem (Join-Path $stageDir 'translations') -Filter 'psi_*.qm' -File -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if (-not $translation) {
+    throw 'No installed Psi translations were found'
+}
+
+Copy-Item (Join-Path $sourceDir 'COPYING') (Join-Path $stageDir 'COPYING')
+Copy-Item (Join-Path $sourceDir 'README.html') (Join-Path $stageDir 'README.html')
+
+Invoke-Checked python packaging/windows/prepare_package_msvc.py `
+    --root $stageDir `
+    --sdk $sdkDir `
+    --qt-root $env:QT_ROOT_DIR `
+    --source-root $sourceDir `
+    --qt-conf (Join-Path $sourceDir 'win32\qt.conf') `
+    --report $report
+
+$baseTag = (git describe --tags --abbrev=0 --exclude 'windows-sdk-*').Trim()
+if (-not $baseTag) {
+    throw 'Could not determine the base Psi version tag'
+}
+$commitCountText = (git rev-list --count "$baseTag..HEAD").Trim()
+$commitCount = [int]$commitCountText
+$appVersion = if ($commitCount -gt 0) { "$baseTag.$commitCount" } else { $baseTag }
+
+$parts = @($appVersion.Split('.'))
+if ($parts.Count -eq 0 -or ($parts | Where-Object { $_ -notmatch '^\d+$' })) {
+    throw "NSIS requires a numeric application version, got: $appVersion"
+}
+while ($parts.Count -lt 4) {
+    $parts += '0'
+}
+if ($parts.Count -gt 4) {
+    $parts = $parts[0..3]
+}
+foreach ($part in $parts) {
+    if ([int]$part -gt 65535) {
+        throw "NSIS version component exceeds 65535: $appVersion"
+    }
+}
+$numericVersion = $parts -join '.'
+
+$psiRevision = (git rev-parse HEAD).Trim()
+$qtVersion = (& "$env:QT_ROOT_DIR\bin\qmake.exe" -query QT_VERSION).Trim()
+@"
+Psi Windows package
+===================
+Psi version: $appVersion
+Psi revision: $psiRevision
+Windows profile: modern
+Compiler: MSVC $env:VCToolsVersion
+Target baseline: Windows 10 (_WIN32_WINNT=0x0A00, WINVER=0x0A00)
+Qt: $qtVersion / QtWebEngine
+Translations: psi-im/psi-l10n $l10nRevision
+"@ | Set-Content (Join-Path $stageDir 'BUILD-INFO.txt') -Encoding utf8
+
+$packageBase = "psi-$appVersion-win10-x64"
+$zipFile = Join-Path $outputDir "$packageBase.zip"
+$setupFile = Join-Path $outputDir "$packageBase-setup.exe"
+$manifest = Join-Path $outputDir 'uninstall-modern.nsh'
+
+Invoke-Checked python packaging/windows/generate_nsis_manifest.py `
+    --root $stageDir `
+    --output $manifest
+
+$needsVcRedist = $false
+$lines = Get-Content $report
+$start = [Array]::IndexOf($lines, 'MSVC runtime imports:')
+if ($start -lt 0) {
+    throw 'Dependency report has no MSVC runtime section'
+}
+for ($i = $start + 1; $i -lt $lines.Count -and $lines[$i].Trim(); ++$i) {
+    if ($lines[$i].Trim() -ne 'none') {
+        $needsVcRedist = $true
+        break
+    }
+}
+
+$nsisRedistArg = $null
+if ($needsVcRedist) {
+    $redist = Join-Path $outputDir 'vc_redist-modern.x64.exe'
+    Invoke-WebRequest `
+        -Uri 'https://aka.ms/vc14/vc_redist.x64.exe' `
+        -OutFile $redist `
+        -MaximumRetryCount 3 `
+        -RetryIntervalSec 3
+    if (-not (Test-Path $redist) -or (Get-Item $redist).Length -eq 0) {
+        throw 'Microsoft Visual C++ Redistributable download failed'
+    }
+    $nsisRedistArg = "-DVC_REDIST=$redist"
+}
+
+Remove-Item $zipFile, $setupFile -Force -ErrorAction SilentlyContinue
+Push-Location $stageDir
+try {
+    Invoke-Checked cmake -E tar cf $zipFile --format=zip .
+} finally {
+    Pop-Location
+}
+Invoke-Checked cmake -E tar tf $zipFile
+
+$makensis = (Get-Command makensis.exe -ErrorAction Stop).Source
+$nsisArgs = @()
+if ($nsisRedistArg) {
+    $nsisArgs += $nsisRedistArg
+}
+$nsisArgs += @(
+    "-DAPP_VERSION=$appVersion",
+    "-DAPP_VERSION_NUMERIC=$numericVersion",
+    "-DSOURCE_DIR=$stageDir",
+    "-DUNINSTALL_MANIFEST=$manifest",
+    "-DOUTPUT_FILE=$setupFile",
+    "-DAPP_ICON=$(Join-Path $sourceDir 'win32\app.ico')",
+    "-DLICENSE_FILE=$(Join-Path $sourceDir 'COPYING')",
+    (Join-Path $sourceDir 'packaging\windows\psi.nsi')
+)
+
+Invoke-Checked $makensis @nsisArgs
+
+if (-not (Test-Path $setupFile) -or (Get-Item $setupFile).Length -eq 0) {
+    throw "Installer was not created: $setupFile"
+}
+
+Set-Content (Join-Path $outputDir 'version-modern.txt') $appVersion -Encoding ascii
+Write-Host "Created $zipFile"
+Write-Host "Created $setupFile"

--- a/packaging/windows/build_profile_msvc.ps1
+++ b/packaging/windows/build_profile_msvc.ps1
@@ -183,33 +183,6 @@ Invoke-Checked python packaging/windows/generate_nsis_manifest.py `
     --root $stageDir `
     --output $manifest
 
-$needsVcRedist = $false
-$lines = Get-Content $report
-$start = [Array]::IndexOf($lines, 'MSVC runtime imports:')
-if ($start -lt 0) {
-    throw 'Dependency report has no MSVC runtime section'
-}
-for ($i = $start + 1; $i -lt $lines.Count -and $lines[$i].Trim(); ++$i) {
-    if ($lines[$i].Trim() -ne 'none') {
-        $needsVcRedist = $true
-        break
-    }
-}
-
-$nsisRedistArg = $null
-if ($needsVcRedist) {
-    $redist = Join-Path $outputDir 'vc_redist-modern.x64.exe'
-    Invoke-WebRequest `
-        -Uri 'https://aka.ms/vc14/vc_redist.x64.exe' `
-        -OutFile $redist `
-        -MaximumRetryCount 3 `
-        -RetryIntervalSec 3
-    if (-not (Test-Path $redist) -or (Get-Item $redist).Length -eq 0) {
-        throw 'Microsoft Visual C++ Redistributable download failed'
-    }
-    $nsisRedistArg = "-DVC_REDIST=$redist"
-}
-
 Remove-Item $zipFile, $setupFile -Force -ErrorAction SilentlyContinue
 Push-Location $stageDir
 try {
@@ -220,11 +193,7 @@ try {
 Invoke-Checked cmake '-E' tar tf $zipFile
 
 $makensis = (Get-Command makensis.exe -ErrorAction Stop).Source
-$nsisArgs = @()
-if ($nsisRedistArg) {
-    $nsisArgs += $nsisRedistArg
-}
-$nsisArgs += @(
+$nsisArgs = @(
     "-DAPP_VERSION=$appVersion",
     "-DAPP_VERSION_NUMERIC=$numericVersion",
     "-DSOURCE_DIR=$stageDir",

--- a/packaging/windows/prepare_package_msvc.py
+++ b/packaging/windows/prepare_package_msvc.py
@@ -197,12 +197,12 @@ def main() -> int:
     system32 = Path(os.environ.get("WINDIR", r"C:\Windows")) / "System32"
     search_dirs = [root, sdk / "bin", qt_root / "bin"]
 
-    redist_root: Path | None = None
+    redist_x64: Path | None = None
     redist_env = os.environ.get("VCToolsRedistDir")
     if redist_env:
-        candidate = Path(redist_env)
+        candidate = Path(redist_env) / "x64"
         if candidate.is_dir():
-            redist_root = candidate
+            redist_x64 = candidate
 
     copied: dict[str, str] = {}
     system: set[str] = set()
@@ -231,10 +231,14 @@ def main() -> int:
                     if candidate:
                         break
 
-                if not candidate and redist_root:
-                    candidate = find_recursive_case_insensitive(redist_root, dll_name)
+                if not candidate and redist_x64:
+                    candidate = find_recursive_case_insensitive(redist_x64, dll_name)
 
                 if candidate:
+                    if not is_pe64(dumpbin, candidate):
+                        raise SystemExit(
+                            f"Non-x64 runtime candidate for {dll_name}: {candidate}"
+                        )
                     shutil.copy2(candidate, root / candidate.name)
                     copied[lowered] = str(candidate)
                     changed = True

--- a/packaging/windows/prepare_package_msvc.py
+++ b/packaging/windows/prepare_package_msvc.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Prepare a self-contained Psi MSVC/Qt6 Windows runtime tree."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DLL_LINE_RE = re.compile(r"^\s*([A-Za-z0-9_.+\-]+\.dll)\s*$", re.IGNORECASE)
+MSVC_RUNTIME_RE = re.compile(
+    r"^(?:vcruntime\d.*|msvcp\d.*|concrt\d.*)\.dll$",
+    re.IGNORECASE,
+)
+
+
+def run(cmd: list[str]) -> str:
+    proc = subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        capture_output=True,
+        errors="replace",
+    )
+    return proc.stdout + proc.stderr
+
+
+def imports(dumpbin: Path, binary: Path) -> list[str]:
+    output = run([str(dumpbin), "/DEPENDENTS", str(binary)])
+    deps: set[str] = set()
+    in_dependencies = False
+
+    for line in output.splitlines():
+        if "Image has the following dependencies:" in line:
+            in_dependencies = True
+            continue
+        if not in_dependencies:
+            continue
+        if line.strip().startswith("Summary"):
+            break
+        match = DLL_LINE_RE.match(line)
+        if match:
+            deps.add(match.group(1))
+
+    return sorted(deps, key=str.lower)
+
+
+def is_pe64(dumpbin: Path, binary: Path) -> bool:
+    output = run([str(dumpbin), "/HEADERS", str(binary)]).lower()
+    return "8664 machine (x64)" in output or "machine (x64)" in output
+
+
+def find_case_insensitive(directory: Path, filename: str) -> Path | None:
+    if not directory.is_dir():
+        return None
+    wanted = filename.lower()
+    for child in directory.iterdir():
+        if child.is_file() and child.name.lower() == wanted:
+            return child
+    return None
+
+
+def find_recursive_case_insensitive(directory: Path, filename: str) -> Path | None:
+    if not directory.is_dir():
+        return None
+    wanted = filename.lower()
+    for child in directory.rglob("*"):
+        if child.is_file() and child.name.lower() == wanted:
+            return child
+    return None
+
+
+def classify_system_dll(system32: Path, name: str) -> bool:
+    lowered = name.lower()
+    if lowered.startswith(("api-ms-win-", "ext-ms-win-")):
+        return True
+    return find_case_insensitive(system32, name) is not None
+
+
+def copy_runtime_data(source_root: Path, root: Path) -> None:
+    myspell = source_root / "myspell"
+    if myspell.is_dir():
+        target = root / "myspell"
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(myspell, target)
+
+
+def copy_sdk_runtime(sdk: Path, root: Path) -> None:
+    sdk_bin = sdk / "bin"
+    if not sdk_bin.is_dir():
+        raise SystemExit(f"SDK bin directory is missing: {sdk_bin}")
+
+    for dll in sorted(sdk_bin.glob("*.dll")):
+        shutil.copy2(dll, root / dll.name)
+
+
+def prune_unused_qt_plugins(root: Path) -> None:
+    # Qt deployment brings all installed SQL drivers when QtSql is linked.
+    # Psi only uses SQLite; keeping other drivers needlessly expands the
+    # dependency closure with database client runtimes.
+    sqldrivers = root / "qtplugins" / "sqldrivers"
+    if not sqldrivers.is_dir():
+        raise SystemExit(f"Qt SQL plugin directory is missing: {sqldrivers}")
+
+    qsqlite = find_case_insensitive(sqldrivers, "qsqlite.dll")
+    if not qsqlite:
+        raise SystemExit(f"Required Qt SQLite plugin is missing from {sqldrivers}")
+
+    for plugin in sqldrivers.glob("*.dll"):
+        if plugin.name.lower() != "qsqlite.dll":
+            plugin.unlink()
+
+
+def collect_pe_files(root: Path) -> list[Path]:
+    return sorted(
+        (
+            path
+            for path in root.rglob("*")
+            if path.is_file() and path.suffix.lower() in {".exe", ".dll"}
+        ),
+        key=lambda path: str(path).lower(),
+    )
+
+
+def locate_dumpbin() -> Path:
+    candidate = shutil.which("dumpbin.exe") or shutil.which("dumpbin")
+    if candidate:
+        return Path(candidate).resolve()
+    raise SystemExit("dumpbin.exe is not available in the MSVC environment")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--sdk", type=Path, required=True)
+    parser.add_argument("--qt-root", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--qt-conf", type=Path, required=True)
+    parser.add_argument("--report", type=Path, required=True)
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    sdk = args.sdk.resolve()
+    qt_root = args.qt_root.resolve()
+    source_root = args.source_root.resolve()
+    qt_conf = args.qt_conf.resolve()
+    report = args.report.resolve()
+
+    psi_exe = root / "psi.exe"
+    if not psi_exe.is_file():
+        raise SystemExit(f"Installed Psi executable is missing: {psi_exe}")
+
+    windeployqt = qt_root / "bin" / "windeployqt.exe"
+    if not windeployqt.is_file():
+        raise SystemExit(f"windeployqt is missing: {windeployqt}")
+
+    dumpbin = locate_dumpbin()
+    qtplugins = root / "qtplugins"
+    translations = root / "translations"
+    qtplugins.mkdir(parents=True, exist_ok=True)
+    translations.mkdir(parents=True, exist_ok=True)
+
+    # Official Qt/MSVC deployment is authoritative for Qt, WebEngine,
+    # QtWebEngineProcess, resources/locales and the app-local compiler runtime.
+    subprocess.run(
+        [
+            str(windeployqt),
+            "--release",
+            "--verbose",
+            "2",
+            "--dir",
+            str(root),
+            "--libdir",
+            str(root),
+            "--plugindir",
+            str(qtplugins),
+            "--translationdir",
+            str(translations),
+            str(psi_exe),
+        ],
+        check=True,
+    )
+
+    prune_unused_qt_plugins(root)
+    shutil.copy2(qt_conf, root / "qt.conf")
+    copy_runtime_data(source_root, root)
+    copy_sdk_runtime(sdk, root)
+
+    system32 = Path(os.environ.get("WINDIR", r"C:\Windows")) / "System32"
+    search_dirs = [root, sdk / "bin", qt_root / "bin"]
+
+    redist_root: Path | None = None
+    redist_env = os.environ.get("VCToolsRedistDir")
+    if redist_env:
+        candidate = Path(redist_env)
+        if candidate.is_dir():
+            redist_root = candidate
+
+    copied: dict[str, str] = {}
+    system: set[str] = set()
+    unresolved: set[str] = set()
+    msvc_runtime: set[str] = set()
+
+    while True:
+        changed = False
+        for binary in collect_pe_files(root):
+            if not is_pe64(dumpbin, binary):
+                raise SystemExit(f"Non-x64 PE file in x64 package: {binary}")
+
+            for dll_name in imports(dumpbin, binary):
+                lowered = dll_name.lower()
+                if MSVC_RUNTIME_RE.match(dll_name):
+                    msvc_runtime.add(dll_name)
+
+                if find_case_insensitive(
+                    binary.parent, dll_name
+                ) or find_case_insensitive(root, dll_name):
+                    continue
+
+                candidate = None
+                for directory in search_dirs:
+                    candidate = find_case_insensitive(directory, dll_name)
+                    if candidate:
+                        break
+
+                if not candidate and redist_root:
+                    candidate = find_recursive_case_insensitive(redist_root, dll_name)
+
+                if candidate:
+                    shutil.copy2(candidate, root / candidate.name)
+                    copied[lowered] = str(candidate)
+                    changed = True
+                    continue
+
+                if classify_system_dll(system32, dll_name):
+                    system.add(dll_name)
+                else:
+                    unresolved.add(dll_name)
+
+        if not changed:
+            break
+        unresolved.clear()
+
+    for binary in collect_pe_files(root):
+        for dll_name in imports(dumpbin, binary):
+            if find_case_insensitive(
+                binary.parent, dll_name
+            ) or find_case_insensitive(root, dll_name):
+                continue
+            if classify_system_dll(system32, dll_name):
+                system.add(dll_name)
+            else:
+                unresolved.add(dll_name)
+
+    report.parent.mkdir(parents=True, exist_ok=True)
+    report.write_text(
+        "Psi Windows MSVC runtime dependency report\n"
+        "==========================================\n\n"
+        "Automatically copied runtime DLLs:\n"
+        + "".join(
+            f"  {name} <- {source}\n" for name, source in sorted(copied.items())
+        )
+        + "\nSystem DLL imports:\n"
+        + "".join(f"  {name}\n" for name in sorted(system, key=str.lower))
+        + "\nMSVC runtime imports:\n"
+        + (
+            "".join(
+                f"  {name}\n" for name in sorted(msvc_runtime, key=str.lower)
+            )
+            or "  none\n"
+        )
+        + "\nUnresolved imports:\n"
+        + (
+            "".join(f"  {name}\n" for name in sorted(unresolved, key=str.lower))
+            or "  none\n"
+        ),
+        encoding="utf-8",
+    )
+
+    if unresolved:
+        print(report.read_text(encoding="utf-8"), file=sys.stderr)
+        raise SystemExit("Unresolved runtime DLL imports remain in the MSVC package")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/windows/prepare_package_msvc.py
+++ b/packaging/windows/prepare_package_msvc.py
@@ -99,7 +99,7 @@ def copy_sdk_runtime(sdk: Path, root: Path) -> None:
         shutil.copy2(dll, root / dll.name)
 
 
-def prune_unused_qt_plugins(root: Path) -> None:
+def prune_unused_qt_plugins(root: Path, dumpbin: Path) -> None:
     # Qt deployment brings all installed SQL drivers when QtSql is linked.
     # Psi only uses SQLite; keeping other drivers needlessly expands the
     # dependency closure with database client runtimes.
@@ -114,6 +114,18 @@ def prune_unused_qt_plugins(root: Path) -> None:
     for plugin in sqldrivers.glob("*.dll"):
         if plugin.name.lower() != "qsqlite.dll":
             plugin.unlink()
+
+    # QtPositioning deploys optional backends as a group. The NMEA serial
+    # backend pulls Qt6SerialPort even though Psi does not use serial NMEA
+    # positioning. Keep the usable positioning backends, but drop any optional
+    # backend that would add QtSerialPort solely for that plugin.
+    position_plugins = root / "qtplugins" / "position"
+    if position_plugins.is_dir():
+        for plugin in position_plugins.glob("*.dll"):
+            dependencies = {name.lower() for name in imports(dumpbin, plugin)}
+            if "qt6serialport.dll" in dependencies:
+                print(f"Pruning unused Qt serial positioning plugin: {plugin}")
+                plugin.unlink()
 
 
 def collect_pe_files(root: Path) -> list[Path]:
@@ -189,7 +201,7 @@ def main() -> int:
         check=True,
     )
 
-    prune_unused_qt_plugins(root)
+    prune_unused_qt_plugins(root, dumpbin)
     shutil.copy2(qt_conf, root / "qt.conf")
     copy_runtime_data(source_root, root)
     copy_sdk_runtime(sdk, root)

--- a/packaging/windows/prepare_package_msvc.py
+++ b/packaging/windows/prepare_package_msvc.py
@@ -166,13 +166,16 @@ def main() -> int:
     translations.mkdir(parents=True, exist_ok=True)
 
     # Official Qt/MSVC deployment is authoritative for Qt, WebEngine,
-    # QtWebEngineProcess, resources/locales and the app-local compiler runtime.
+    # QtWebEngineProcess and resources/locales. Compiler runtime deployment is
+    # disabled here because the dependency closure below handles app-local DLLs
+    # explicitly and the NSIS path can install the official VC redistributable.
     subprocess.run(
         [
             str(windeployqt),
             "--release",
             "--verbose",
             "2",
+            "--no-compiler-runtime",
             "--dir",
             str(root),
             "--libdir",


### PR DESCRIPTION
## Summary

Split the Windows packaging toolchains by supported OS generation.

- keep the Windows 7 compatibility package on MSYS2/MinGW64 + Qt5 + QtWebKit
- move the required modern Windows 10/11 package to MSVC 2022 + official Qt 6.11 + QtWebEngine
- add a separate `windows-sdk-msvc-qt6-v1` dependency SDK for OpenSSL, zlib, Hunspell, minizip and static Qt6Keychain
- keep Qt itself outside the SDK and install the official `win64_msvc2022_64` binaries, including WebEngine, during CI
- keep bundled Iris/QCA/usrsctp/OMEMO for the first MSVC migration step, with bundled QCA pinned to v3.0.1
- retain the canonical portable ZIP + NSIS staging model and recursive PE runtime dependency validation

The modern profile remains the blocking PR build. The Windows 7 profile runs only on `master`/manual dispatch and remains best-effort.